### PR TITLE
Update urls in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "directories": {
     "test": "tests"
   },
-  "repository": "https://github.com/tim-evans/ember-page-title",
+  "repository": "https://github.com/adopted-ember-addons/ember-page-title",
   "scripts": {
     "build": "ember build",
     "lint:js": "eslint ./*.js addon addon-test-support app config lib server test-support tests",
@@ -57,7 +57,7 @@
   },
   "ember-addon": {
     "configPath": "tests/dummy/config",
-    "demoURL": "http://tim-evans.github.io/ember-page-title/"
+    "demoURL": "https://adopted-ember-addons.github.io/ember-page-title/"
   },
-  "homepage": "https://tim-evans.github.io/ember-page-title"
+  "homepage": "https://adopted-ember-addons.github.io/ember-page-title/"
 }


### PR DESCRIPTION
The package.json file still linked to the old repository and demo site.