### PR TITLE
Fix for #142

### DIFF
--- a/app/services/page-title-list.js
+++ b/app/services/page-title-list.js
@@ -7,7 +7,7 @@ function capitalize(key) {
 
 let defaults = {};
 ['separator', 'prepend', 'replace'].forEach(function (key) {
-  if (config.pageTitle && config.pageTitle[key]) {
+  if (config.pageTitle && (config.pageTitle[key] !== null) && (config.pageTitle[key] !== undefined)) {
     defaults[`default${capitalize(key)}`] = config.pageTitle[key];
   }
 });


### PR DESCRIPTION
Explicit check for not-null and not-undefined when setting the default values from the configuration.

The current code will not set defaultPrepend / defaultReplace to "false" because the check will fail. The Pr fixes #142 