### PR TITLE
Make it possible to specify that a token should ALWAYS be in front

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ This file is added automatically if you use `ember install`. This is for all the
 | separator | string  | `" \| "`|
 | prepend   | boolean | true    |
 | replace   | boolean | false   |
+| front     | boolean | false   |
 
 These defaults are configurable in `config/environment.js`:
 

--- a/addon/services/page-title-list.js
+++ b/addon/services/page-title-list.js
@@ -147,8 +147,11 @@ export default Service.extend({
       let appending = true;
       let group = [];
       let groups = A([group]);
+      let frontGroups = [];
       visible.forEach((token) => {
-        if (token.prepend) {
+        if (token.front) {
+          frontGroups.unshift(token);
+        } else if (token.prepend) {
           if (appending) {
             appending = false;
             group = [];
@@ -170,7 +173,9 @@ export default Service.extend({
         }
       });
 
-      return groups.reduce((E, group) => E.concat(group), []);
+      return frontGroups.concat(
+        groups.reduce((E, group) => E.concat(group), [])
+      );
     }
   }),
 

--- a/tests/acceptance/posts-test.js
+++ b/tests/acceptance/posts-test.js
@@ -85,4 +85,11 @@ module('Acceptance: title', function(hooks) {
     });
     assert.equal(title(), 'Tomster (@tomster)');
   });
+
+  test('front tokens work', async function (assert) {
+    assert.expect(1);
+    await visit('/reader');
+
+    assert.equal(title(), '(10) Reader | My App');
+  });
 });

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -17,6 +17,7 @@ Router.map(function() {
   this.route('author', { path: '/authors/:author_id' });
   this.route('hollywood', { path: '/hollywood' });
   this.route('feed', { path: '/feeds/:name' });
+  this.route('reader', { path: '/reader' });
 });
 
 export default Router;

--- a/tests/dummy/app/routes/reader.js
+++ b/tests/dummy/app/routes/reader.js
@@ -1,0 +1,7 @@
+import Route from '@ember/routing/route';
+
+export default Route.extend({
+  model: function () {
+    return {};
+  }
+});

--- a/tests/dummy/app/templates/reader.hbs
+++ b/tests/dummy/app/templates/reader.hbs
@@ -1,0 +1,3 @@
+{{title "Reader"}}
+
+{{title "(10)" front=true separator=" "}}


### PR DESCRIPTION
Add a new attribute called `front` to ensure that the token is ALWAYS appended at the start. The use case for our product:

We have an unread indicator in the title (like a lot of other softwares :) that looks like this `(10) Feeder`, and even though you are on a sub-page like "Edit feeds" you should see the unread indicator in the start of the title: `(10) Edit feeds | Feeder`.

Currently using a honed mix of `prepend=false` and `prepend=true` could maybe in some cases solve the issue, but not elegantly.
