### PR TITLE
Fix #148 (dummy): currentRouteName deprecation

### DIFF
--- a/tests/dummy/app/controllers/application.js
+++ b/tests/dummy/app/controllers/application.js
@@ -1,0 +1,6 @@
+import Controller from '@ember/controller';
+import { inject as service } from '@ember/service';
+
+export default Controller.extend({
+  router: service()
+});

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -1,6 +1,6 @@
 {{! template-lint-disable simple-unless }}
 {{head-layout}}
-{{#unless (equals currentRouteName "index")}}
+{{#unless (equals router.currentRouteName "index")}}
   {{title "My App"}}
 {{/unless}}
 {{outlet}}


### PR DESCRIPTION
This PR solves the deprecation warning triggered by `currentRouteName` mentioned in the issue #148 .