### PR TITLE
Migrate away from ember-cli-head for <title> updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,16 +8,14 @@ This addon provides a helper for changing the title of the page you're on.
 ember install ember-page-title
 ```
 
-Add `{{head-layout}}` to your application's `application.hbs` template.
-
-<details>
-<summary>Fastboot vs Non-Fastboot Notes</summary>
-
 ### Compatibility
 
 * Ember.js v3.12 or above
 * Ember CLI v2.13 or above
 * Node.js v10 or above
+
+<details>
+<summary>Fastboot vs Non-Fastboot Notes</summary>
 
 #### Post Install Cleanup
 
@@ -60,20 +58,16 @@ module.exports = function (environment) {
 };
 ```
 
-### Fastboot
-
-When working with other addons that use `ember-cli-head`, you'll need to create a custom `head.hbs` file that exposes the `<title>` tag properly:
-
-```hbs
-<title>{{model.title}}</title>
-```
-
-This file is added automatically if you use `ember install`. This is for all the folks using ember-cli-head addons like ember-cli-meta-tags.
-
 ### Deprecations
 
 - Since **v5.2.2**: The `{{title}}` helper has been deprecated, use `{{page-title}}` instead, it has the same API. The
   `{{title}}` helper was an AST transform and will be removed in the next major release.
+
+### Upgrading notes for 5.x to 6.x
+
+`ember-page-title` no longer requires the usage of `ember-cli-head`.
+
+Please remove `{{head-layout}}` from your application's `application.hbs` route template.
 
 ### Upgrading notes for 3.x to 4.x
 

--- a/addon/services/page-title-list.js
+++ b/addon/services/page-title-list.js
@@ -194,8 +194,7 @@ export default Service.extend({
 
   scheduleTitleUpdate() {
     let router = getOwner(this).lookup('router:main');
-    let routes = router._routerMicrolib || router.router;
-    let { activeTransition } = routes || {};
+    let { activeTransition } = router._routerMicrolib;
     if (activeTransition) {
       activeTransition.promise.finally(() => {
         if (this.isDestroyed) {

--- a/app/templates/head.hbs
+++ b/app/templates/head.hbs
@@ -1,6 +1,0 @@
-{{! template-lint-disable no-html-comments }}
-<!-- `app/templates/head.hbs` -->
-<!-- content from ember-page-title, injected by ember-cli-head -->
-<!-- The 'model' available in this template can be populated by -->
-<!-- setting values on the 'head-data' service. -->
-<title>{{model.title}}</title>

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,11 +38,6 @@
           "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001117.tgz",
           "integrity": "sha512-4tY0Fatzdx59kYjQs+bNxUwZB03ZEBgVmJ1UkFPz/Q8OLiUUbjct2EdpnXj0fvFTPej2EkbPIG0w8BWsjAyk1Q=="
         },
-        "electron-to-chromium": {
-          "version": "1.3.545",
-          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.545.tgz",
-          "integrity": "sha512-+0R/i17u5E1cwF3g0W8Niq3UUKTUMyyT4kLkutZUHG8mDNvFsAckK3HIanzGVtixe3b6rknD8k7gHiR6nKFkgg=="
-        },
         "node-releases": {
           "version": "1.1.60",
           "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.60.tgz",
@@ -91,11 +86,6 @@
         "@babel/types": "^7.10.4"
       },
       "dependencies": {
-        "@babel/helper-validator-identifier": {
-          "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
-          "integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw=="
-        },
         "@babel/types": {
           "version": "7.11.0",
           "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.11.0.tgz",
@@ -122,11 +112,6 @@
         "@babel/types": "^7.10.4"
       },
       "dependencies": {
-        "@babel/helper-validator-identifier": {
-          "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
-          "integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw=="
-        },
         "@babel/types": {
           "version": "7.11.0",
           "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.11.0.tgz",
@@ -172,11 +157,6 @@
           "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001117.tgz",
           "integrity": "sha512-4tY0Fatzdx59kYjQs+bNxUwZB03ZEBgVmJ1UkFPz/Q8OLiUUbjct2EdpnXj0fvFTPej2EkbPIG0w8BWsjAyk1Q=="
         },
-        "electron-to-chromium": {
-          "version": "1.3.545",
-          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.545.tgz",
-          "integrity": "sha512-+0R/i17u5E1cwF3g0W8Niq3UUKTUMyyT4kLkutZUHG8mDNvFsAckK3HIanzGVtixe3b6rknD8k7gHiR6nKFkgg=="
-        },
         "node-releases": {
           "version": "1.1.60",
           "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.60.tgz",
@@ -188,6 +168,7 @@
       "version": "7.8.3",
       "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.8.3.tgz",
       "integrity": "sha512-qmp4pD7zeTxsv0JNecSBsEmG1ei2MqwJq4YQcK3ZWm/0t07QstWfvuV/vm3Qt5xNMFETn2SZqpMx2MQzbtq+KA==",
+      "dev": true,
       "requires": {
         "@babel/helper-function-name": "^7.8.3",
         "@babel/helper-member-expression-to-functions": "^7.8.3",
@@ -242,11 +223,6 @@
             "@babel/types": "^7.10.4"
           }
         },
-        "@babel/helper-validator-identifier": {
-          "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
-          "integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw=="
-        },
         "@babel/highlight": {
           "version": "7.10.4",
           "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
@@ -297,11 +273,6 @@
         "@babel/types": "^7.10.4"
       },
       "dependencies": {
-        "@babel/helper-validator-identifier": {
-          "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
-          "integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw=="
-        },
         "@babel/types": {
           "version": "7.11.0",
           "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.11.0.tgz",
@@ -345,11 +316,6 @@
         "@babel/types": "^7.10.4"
       },
       "dependencies": {
-        "@babel/helper-validator-identifier": {
-          "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
-          "integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw=="
-        },
         "@babel/types": {
           "version": "7.11.0",
           "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.11.0.tgz",
@@ -371,6 +337,7 @@
       "version": "7.8.3",
       "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.8.3.tgz",
       "integrity": "sha512-fO4Egq88utkQFjbPrSHGmGLFqmrshs11d46WI+WZDESt7Wu7wN2G2Iu+NMMZJFDOVRHAMIkB5SNh30NtwCA7RA==",
+      "dev": true,
       "requires": {
         "@babel/types": "^7.8.3"
       }
@@ -383,11 +350,6 @@
         "@babel/types": "^7.10.4"
       },
       "dependencies": {
-        "@babel/helper-validator-identifier": {
-          "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
-          "integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw=="
-        },
         "@babel/types": {
           "version": "7.11.0",
           "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.11.0.tgz",
@@ -490,11 +452,6 @@
             "@babel/types": "^7.11.0"
           }
         },
-        "@babel/helper-validator-identifier": {
-          "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
-          "integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw=="
-        },
         "@babel/highlight": {
           "version": "7.10.4",
           "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
@@ -557,6 +514,7 @@
       "version": "7.8.3",
       "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.8.3.tgz",
       "integrity": "sha512-Kag20n86cbO2AvHca6EJsvqAd82gc6VMGule4HwebwMlwkpXuVqrNRj6CkCV2sKxgi9MyAUnZVnZ6lJ1/vKhHQ==",
+      "dev": true,
       "requires": {
         "@babel/types": "^7.8.3"
       }
@@ -592,11 +550,6 @@
           "requires": {
             "@babel/highlight": "^7.10.4"
           }
-        },
-        "@babel/helper-validator-identifier": {
-          "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
-          "integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw=="
         },
         "@babel/highlight": {
           "version": "7.10.4",
@@ -644,6 +597,7 @@
       "version": "7.8.3",
       "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.8.3.tgz",
       "integrity": "sha512-xOUssL6ho41U81etpLoT2RTdvdus4VfHamCuAm4AHxGr+0it5fnwoVdwUJ7GFEqCsQYzJUhcbsN9wB9apcYKFA==",
+      "dev": true,
       "requires": {
         "@babel/helper-member-expression-to-functions": "^7.8.3",
         "@babel/helper-optimise-call-expression": "^7.8.3",
@@ -667,11 +621,6 @@
           "requires": {
             "@babel/highlight": "^7.10.4"
           }
-        },
-        "@babel/helper-validator-identifier": {
-          "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
-          "integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw=="
         },
         "@babel/highlight": {
           "version": "7.10.4",
@@ -723,11 +672,6 @@
         "@babel/types": "^7.11.0"
       },
       "dependencies": {
-        "@babel/helper-validator-identifier": {
-          "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
-          "integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw=="
-        },
         "@babel/types": {
           "version": "7.11.0",
           "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.11.0.tgz",
@@ -754,9 +698,9 @@
       }
     },
     "@babel/helper-validator-identifier": {
-      "version": "7.10.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.1.tgz",
-      "integrity": "sha512-5vW/JXLALhczRCWP0PnFDMCJAchlBvM7f4uk/jXritBnIa6E1KmqmtrS3yn1LAnxFBypQ3eneLuXjsnfQsgILw=="
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
+      "integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw=="
     },
     "@babel/helper-wrap-function": {
       "version": "7.10.4",
@@ -812,11 +756,6 @@
           "requires": {
             "@babel/types": "^7.11.0"
           }
-        },
-        "@babel/helper-validator-identifier": {
-          "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
-          "integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw=="
         },
         "@babel/highlight": {
           "version": "7.10.4",
@@ -922,19 +861,167 @@
       "version": "7.8.3",
       "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.8.3.tgz",
       "integrity": "sha512-EqFhbo7IosdgPgZggHaNObkmO1kNUe3slaKu54d5OWvy+p9QIKOzK1GAEpAIsZtWVtPXUHSMcT4smvDrCfY4AA==",
+      "dev": true,
       "requires": {
         "@babel/helper-create-class-features-plugin": "^7.8.3",
         "@babel/helper-plugin-utils": "^7.8.3"
       }
     },
     "@babel/plugin-proposal-decorators": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-decorators/-/plugin-proposal-decorators-7.8.3.tgz",
-      "integrity": "sha512-e3RvdvS4qPJVTe288DlXjwKflpfy1hr0j5dz5WpIYYeP7vQZg2WfAEIp8k5/Lwis/m5REXEteIz6rrcDtXXG7w==",
+      "version": "7.10.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-decorators/-/plugin-proposal-decorators-7.10.5.tgz",
+      "integrity": "sha512-Sc5TAQSZuLzgY0664mMDn24Vw2P8g/VhyLyGPaWiHahhgLqeZvcGeyBZOrJW0oSKIK2mvQ22a1ENXBIQLhrEiQ==",
       "requires": {
-        "@babel/helper-create-class-features-plugin": "^7.8.3",
-        "@babel/helper-plugin-utils": "^7.8.3",
-        "@babel/plugin-syntax-decorators": "^7.8.3"
+        "@babel/helper-create-class-features-plugin": "^7.10.5",
+        "@babel/helper-plugin-utils": "^7.10.4",
+        "@babel/plugin-syntax-decorators": "^7.10.4"
+      },
+      "dependencies": {
+        "@babel/code-frame": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
+          "integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
+          "requires": {
+            "@babel/highlight": "^7.10.4"
+          }
+        },
+        "@babel/generator": {
+          "version": "7.11.4",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.11.4.tgz",
+          "integrity": "sha512-Rn26vueFx0eOoz7iifCN2UHT6rGtnkSGWSoDRIy8jZN3B91PzeSULbswfLoOWuTuAcNwpG/mxy+uCTDnZ9Mp1g==",
+          "requires": {
+            "@babel/types": "^7.11.0",
+            "jsesc": "^2.5.1",
+            "source-map": "^0.5.0"
+          }
+        },
+        "@babel/helper-create-class-features-plugin": {
+          "version": "7.10.5",
+          "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.10.5.tgz",
+          "integrity": "sha512-0nkdeijB7VlZoLT3r/mY3bUkw3T8WG/hNw+FATs/6+pG2039IJWjTYL0VTISqsNHMUTEnwbVnc89WIJX9Qed0A==",
+          "requires": {
+            "@babel/helper-function-name": "^7.10.4",
+            "@babel/helper-member-expression-to-functions": "^7.10.5",
+            "@babel/helper-optimise-call-expression": "^7.10.4",
+            "@babel/helper-plugin-utils": "^7.10.4",
+            "@babel/helper-replace-supers": "^7.10.4",
+            "@babel/helper-split-export-declaration": "^7.10.4"
+          }
+        },
+        "@babel/helper-function-name": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.10.4.tgz",
+          "integrity": "sha512-YdaSyz1n8gY44EmN7x44zBn9zQ1Ry2Y+3GTA+3vH6Mizke1Vw0aWDM66FOYEPw8//qKkmqOckrGgTYa+6sceqQ==",
+          "requires": {
+            "@babel/helper-get-function-arity": "^7.10.4",
+            "@babel/template": "^7.10.4",
+            "@babel/types": "^7.10.4"
+          }
+        },
+        "@babel/helper-get-function-arity": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.10.4.tgz",
+          "integrity": "sha512-EkN3YDB+SRDgiIUnNgcmiD361ti+AVbL3f3Henf6dqqUyr5dMsorno0lJWJuLhDhkI5sYEpgj6y9kB8AOU1I2A==",
+          "requires": {
+            "@babel/types": "^7.10.4"
+          }
+        },
+        "@babel/helper-member-expression-to-functions": {
+          "version": "7.11.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.11.0.tgz",
+          "integrity": "sha512-JbFlKHFntRV5qKw3YC0CvQnDZ4XMwgzzBbld7Ly4Mj4cbFy3KywcR8NtNctRToMWJOVvLINJv525Gd6wwVEx/Q==",
+          "requires": {
+            "@babel/types": "^7.11.0"
+          }
+        },
+        "@babel/helper-optimise-call-expression": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.10.4.tgz",
+          "integrity": "sha512-n3UGKY4VXwXThEiKrgRAoVPBMqeoPgHVqiHZOanAJCG9nQUL2pLRQirUzl0ioKclHGpGqRgIOkgcIJaIWLpygg==",
+          "requires": {
+            "@babel/types": "^7.10.4"
+          }
+        },
+        "@babel/helper-plugin-utils": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.4.tgz",
+          "integrity": "sha512-O4KCvQA6lLiMU9l2eawBPMf1xPP8xPfB3iEQw150hOVTqj/rfXz0ThTb4HEzqQfs2Bmo5Ay8BzxfzVtBrr9dVg=="
+        },
+        "@babel/helper-replace-supers": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.10.4.tgz",
+          "integrity": "sha512-sPxZfFXocEymYTdVK1UNmFPBN+Hv5mJkLPsYWwGBxZAxaWfFu+xqp7b6qWD0yjNuNL2VKc6L5M18tOXUP7NU0A==",
+          "requires": {
+            "@babel/helper-member-expression-to-functions": "^7.10.4",
+            "@babel/helper-optimise-call-expression": "^7.10.4",
+            "@babel/traverse": "^7.10.4",
+            "@babel/types": "^7.10.4"
+          }
+        },
+        "@babel/helper-split-export-declaration": {
+          "version": "7.11.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.11.0.tgz",
+          "integrity": "sha512-74Vejvp6mHkGE+m+k5vHY93FX2cAtrw1zXrZXRlG4l410Nm9PxfEiVTn1PjDPV5SnmieiueY4AFg2xqhNFuuZg==",
+          "requires": {
+            "@babel/types": "^7.11.0"
+          }
+        },
+        "@babel/highlight": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
+          "integrity": "sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==",
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.10.4",
+            "chalk": "^2.0.0",
+            "js-tokens": "^4.0.0"
+          }
+        },
+        "@babel/parser": {
+          "version": "7.11.4",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.11.4.tgz",
+          "integrity": "sha512-MggwidiH+E9j5Sh8pbrX5sJvMcsqS5o+7iB42M9/k0CD63MjYbdP4nhSh7uB5wnv2/RVzTZFTxzF/kIa5mrCqA=="
+        },
+        "@babel/template": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.10.4.tgz",
+          "integrity": "sha512-ZCjD27cGJFUB6nmCB1Enki3r+L5kJveX9pq1SvAUKoICy6CZ9yD8xO086YXdYhvNjBdnekm4ZnaP5yC8Cs/1tA==",
+          "requires": {
+            "@babel/code-frame": "^7.10.4",
+            "@babel/parser": "^7.10.4",
+            "@babel/types": "^7.10.4"
+          }
+        },
+        "@babel/traverse": {
+          "version": "7.11.0",
+          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.11.0.tgz",
+          "integrity": "sha512-ZB2V+LskoWKNpMq6E5UUCrjtDUh5IOTAyIl0dTjIEoXum/iKWkoIEKIRDnUucO6f+2FzNkE0oD4RLKoPIufDtg==",
+          "requires": {
+            "@babel/code-frame": "^7.10.4",
+            "@babel/generator": "^7.11.0",
+            "@babel/helper-function-name": "^7.10.4",
+            "@babel/helper-split-export-declaration": "^7.11.0",
+            "@babel/parser": "^7.11.0",
+            "@babel/types": "^7.11.0",
+            "debug": "^4.1.0",
+            "globals": "^11.1.0",
+            "lodash": "^4.17.19"
+          }
+        },
+        "@babel/types": {
+          "version": "7.11.0",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.11.0.tgz",
+          "integrity": "sha512-O53yME4ZZI0jO1EVGtF1ePGl0LHirG4P1ibcD80XyzZcKhcMFeCXmh4Xb1ifGBIV233Qg12x4rBfQgA+tmOukA==",
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.10.4",
+            "lodash": "^4.17.19",
+            "to-fast-properties": "^2.0.0"
+          }
+        },
+        "lodash": {
+          "version": "4.17.20",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
+        }
       }
     },
     "@babel/plugin-proposal-dynamic-import": {
@@ -1018,18 +1105,18 @@
       }
     },
     "@babel/plugin-proposal-numeric-separator": {
-      "version": "7.10.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-numeric-separator/-/plugin-proposal-numeric-separator-7.10.1.tgz",
-      "integrity": "sha512-jjfym4N9HtCiNfyyLAVD8WqPYeHUrw4ihxuAynWj6zzp2gf9Ey2f7ImhFm6ikB3CLf5Z/zmcJDri6B4+9j9RsA==",
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-numeric-separator/-/plugin-proposal-numeric-separator-7.10.4.tgz",
+      "integrity": "sha512-73/G7QoRoeNkLZFxsoCCvlg4ezE4eM+57PnOqgaPOozd5myfj7p0muD1mRVJvbUWbOzD+q3No2bWbaKy+DJ8DA==",
       "requires": {
-        "@babel/helper-plugin-utils": "^7.10.1",
-        "@babel/plugin-syntax-numeric-separator": "^7.10.1"
+        "@babel/helper-plugin-utils": "^7.10.4",
+        "@babel/plugin-syntax-numeric-separator": "^7.10.4"
       },
       "dependencies": {
         "@babel/helper-plugin-utils": {
-          "version": "7.10.1",
-          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.1.tgz",
-          "integrity": "sha512-fvoGeXt0bJc7VMWZGCAEBEMo/HAjW2mP8apF5eXK0wSqwLAVHAISCWRoLMBMUs2kqeaG77jltVqu4Hn8Egl3nA=="
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.4.tgz",
+          "integrity": "sha512-O4KCvQA6lLiMU9l2eawBPMf1xPP8xPfB3iEQw150hOVTqj/rfXz0ThTb4HEzqQfs2Bmo5Ay8BzxfzVtBrr9dVg=="
         }
       }
     },
@@ -1084,154 +1171,158 @@
       }
     },
     "@babel/plugin-proposal-private-methods": {
-      "version": "7.10.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-methods/-/plugin-proposal-private-methods-7.10.1.tgz",
-      "integrity": "sha512-RZecFFJjDiQ2z6maFprLgrdnm0OzoC23Mx89xf1CcEsxmHuzuXOdniEuI+S3v7vjQG4F5sa6YtUp+19sZuSxHg==",
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-methods/-/plugin-proposal-private-methods-7.10.4.tgz",
+      "integrity": "sha512-wh5GJleuI8k3emgTg5KkJK6kHNsGEr0uBTDBuQUBJwckk9xs1ez79ioheEVVxMLyPscB0LfkbVHslQqIzWV6Bw==",
       "requires": {
-        "@babel/helper-create-class-features-plugin": "^7.10.1",
-        "@babel/helper-plugin-utils": "^7.10.1"
+        "@babel/helper-create-class-features-plugin": "^7.10.4",
+        "@babel/helper-plugin-utils": "^7.10.4"
       },
       "dependencies": {
         "@babel/code-frame": {
-          "version": "7.10.1",
-          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.1.tgz",
-          "integrity": "sha512-IGhtTmpjGbYzcEDOw7DcQtbQSXcG9ftmAXtWTu9V936vDye4xjjekktFAtgZsWpzTj/X01jocB46mTywm/4SZw==",
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
+          "integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
           "requires": {
-            "@babel/highlight": "^7.10.1"
+            "@babel/highlight": "^7.10.4"
           }
         },
         "@babel/generator": {
-          "version": "7.10.2",
-          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.10.2.tgz",
-          "integrity": "sha512-AxfBNHNu99DTMvlUPlt1h2+Hn7knPpH5ayJ8OqDWSeLld+Fi2AYBTC/IejWDM9Edcii4UzZRCsbUt0WlSDsDsA==",
+          "version": "7.11.4",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.11.4.tgz",
+          "integrity": "sha512-Rn26vueFx0eOoz7iifCN2UHT6rGtnkSGWSoDRIy8jZN3B91PzeSULbswfLoOWuTuAcNwpG/mxy+uCTDnZ9Mp1g==",
           "requires": {
-            "@babel/types": "^7.10.2",
+            "@babel/types": "^7.11.0",
             "jsesc": "^2.5.1",
-            "lodash": "^4.17.13",
             "source-map": "^0.5.0"
           }
         },
         "@babel/helper-create-class-features-plugin": {
-          "version": "7.10.2",
-          "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.10.2.tgz",
-          "integrity": "sha512-5C/QhkGFh1vqcziq1vAL6SI9ymzUp8BCYjFpvYVhWP4DlATIb3u5q3iUd35mvlyGs8fO7hckkW7i0tmH+5+bvQ==",
+          "version": "7.10.5",
+          "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.10.5.tgz",
+          "integrity": "sha512-0nkdeijB7VlZoLT3r/mY3bUkw3T8WG/hNw+FATs/6+pG2039IJWjTYL0VTISqsNHMUTEnwbVnc89WIJX9Qed0A==",
           "requires": {
-            "@babel/helper-function-name": "^7.10.1",
-            "@babel/helper-member-expression-to-functions": "^7.10.1",
-            "@babel/helper-optimise-call-expression": "^7.10.1",
-            "@babel/helper-plugin-utils": "^7.10.1",
-            "@babel/helper-replace-supers": "^7.10.1",
-            "@babel/helper-split-export-declaration": "^7.10.1"
+            "@babel/helper-function-name": "^7.10.4",
+            "@babel/helper-member-expression-to-functions": "^7.10.5",
+            "@babel/helper-optimise-call-expression": "^7.10.4",
+            "@babel/helper-plugin-utils": "^7.10.4",
+            "@babel/helper-replace-supers": "^7.10.4",
+            "@babel/helper-split-export-declaration": "^7.10.4"
           }
         },
         "@babel/helper-function-name": {
-          "version": "7.10.1",
-          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.10.1.tgz",
-          "integrity": "sha512-fcpumwhs3YyZ/ttd5Rz0xn0TpIwVkN7X0V38B9TWNfVF42KEkhkAAuPCQ3oXmtTRtiPJrmZ0TrfS0GKF0eMaRQ==",
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.10.4.tgz",
+          "integrity": "sha512-YdaSyz1n8gY44EmN7x44zBn9zQ1Ry2Y+3GTA+3vH6Mizke1Vw0aWDM66FOYEPw8//qKkmqOckrGgTYa+6sceqQ==",
           "requires": {
-            "@babel/helper-get-function-arity": "^7.10.1",
-            "@babel/template": "^7.10.1",
-            "@babel/types": "^7.10.1"
+            "@babel/helper-get-function-arity": "^7.10.4",
+            "@babel/template": "^7.10.4",
+            "@babel/types": "^7.10.4"
           }
         },
         "@babel/helper-get-function-arity": {
-          "version": "7.10.1",
-          "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.10.1.tgz",
-          "integrity": "sha512-F5qdXkYGOQUb0hpRaPoetF9AnsXknKjWMZ+wmsIRsp5ge5sFh4c3h1eH2pRTTuy9KKAA2+TTYomGXAtEL2fQEw==",
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.10.4.tgz",
+          "integrity": "sha512-EkN3YDB+SRDgiIUnNgcmiD361ti+AVbL3f3Henf6dqqUyr5dMsorno0lJWJuLhDhkI5sYEpgj6y9kB8AOU1I2A==",
           "requires": {
-            "@babel/types": "^7.10.1"
+            "@babel/types": "^7.10.4"
           }
         },
         "@babel/helper-member-expression-to-functions": {
-          "version": "7.10.1",
-          "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.10.1.tgz",
-          "integrity": "sha512-u7XLXeM2n50gb6PWJ9hoO5oO7JFPaZtrh35t8RqKLT1jFKj9IWeD1zrcrYp1q1qiZTdEarfDWfTIP8nGsu0h5g==",
+          "version": "7.11.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.11.0.tgz",
+          "integrity": "sha512-JbFlKHFntRV5qKw3YC0CvQnDZ4XMwgzzBbld7Ly4Mj4cbFy3KywcR8NtNctRToMWJOVvLINJv525Gd6wwVEx/Q==",
           "requires": {
-            "@babel/types": "^7.10.1"
+            "@babel/types": "^7.11.0"
           }
         },
         "@babel/helper-optimise-call-expression": {
-          "version": "7.10.1",
-          "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.10.1.tgz",
-          "integrity": "sha512-a0DjNS1prnBsoKx83dP2falChcs7p3i8VMzdrSbfLhuQra/2ENC4sbri34dz/rWmDADsmF1q5GbfaXydh0Jbjg==",
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.10.4.tgz",
+          "integrity": "sha512-n3UGKY4VXwXThEiKrgRAoVPBMqeoPgHVqiHZOanAJCG9nQUL2pLRQirUzl0ioKclHGpGqRgIOkgcIJaIWLpygg==",
           "requires": {
-            "@babel/types": "^7.10.1"
+            "@babel/types": "^7.10.4"
           }
         },
         "@babel/helper-plugin-utils": {
-          "version": "7.10.1",
-          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.1.tgz",
-          "integrity": "sha512-fvoGeXt0bJc7VMWZGCAEBEMo/HAjW2mP8apF5eXK0wSqwLAVHAISCWRoLMBMUs2kqeaG77jltVqu4Hn8Egl3nA=="
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.4.tgz",
+          "integrity": "sha512-O4KCvQA6lLiMU9l2eawBPMf1xPP8xPfB3iEQw150hOVTqj/rfXz0ThTb4HEzqQfs2Bmo5Ay8BzxfzVtBrr9dVg=="
         },
         "@babel/helper-replace-supers": {
-          "version": "7.10.1",
-          "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.10.1.tgz",
-          "integrity": "sha512-SOwJzEfpuQwInzzQJGjGaiG578UYmyi2Xw668klPWV5n07B73S0a9btjLk/52Mlcxa+5AdIYqws1KyXRfMoB7A==",
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.10.4.tgz",
+          "integrity": "sha512-sPxZfFXocEymYTdVK1UNmFPBN+Hv5mJkLPsYWwGBxZAxaWfFu+xqp7b6qWD0yjNuNL2VKc6L5M18tOXUP7NU0A==",
           "requires": {
-            "@babel/helper-member-expression-to-functions": "^7.10.1",
-            "@babel/helper-optimise-call-expression": "^7.10.1",
-            "@babel/traverse": "^7.10.1",
-            "@babel/types": "^7.10.1"
+            "@babel/helper-member-expression-to-functions": "^7.10.4",
+            "@babel/helper-optimise-call-expression": "^7.10.4",
+            "@babel/traverse": "^7.10.4",
+            "@babel/types": "^7.10.4"
           }
         },
         "@babel/helper-split-export-declaration": {
-          "version": "7.10.1",
-          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.10.1.tgz",
-          "integrity": "sha512-UQ1LVBPrYdbchNhLwj6fetj46BcFwfS4NllJo/1aJsT+1dLTEnXJL0qHqtY7gPzF8S2fXBJamf1biAXV3X077g==",
+          "version": "7.11.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.11.0.tgz",
+          "integrity": "sha512-74Vejvp6mHkGE+m+k5vHY93FX2cAtrw1zXrZXRlG4l410Nm9PxfEiVTn1PjDPV5SnmieiueY4AFg2xqhNFuuZg==",
           "requires": {
-            "@babel/types": "^7.10.1"
+            "@babel/types": "^7.11.0"
           }
         },
         "@babel/highlight": {
-          "version": "7.10.1",
-          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.1.tgz",
-          "integrity": "sha512-8rMof+gVP8mxYZApLF/JgNDAkdKa+aJt3ZYxF8z6+j/hpeXL7iMsKCPHa2jNMHu/qqBwzQF4OHNoYi8dMA/rYg==",
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
+          "integrity": "sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==",
           "requires": {
-            "@babel/helper-validator-identifier": "^7.10.1",
+            "@babel/helper-validator-identifier": "^7.10.4",
             "chalk": "^2.0.0",
             "js-tokens": "^4.0.0"
           }
         },
         "@babel/parser": {
-          "version": "7.10.2",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.10.2.tgz",
-          "integrity": "sha512-PApSXlNMJyB4JiGVhCOlzKIif+TKFTvu0aQAhnTvfP/z3vVSN6ZypH5bfUNwFXXjRQtUEBNFd2PtmCmG2Py3qQ=="
+          "version": "7.11.4",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.11.4.tgz",
+          "integrity": "sha512-MggwidiH+E9j5Sh8pbrX5sJvMcsqS5o+7iB42M9/k0CD63MjYbdP4nhSh7uB5wnv2/RVzTZFTxzF/kIa5mrCqA=="
         },
         "@babel/template": {
-          "version": "7.10.1",
-          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.10.1.tgz",
-          "integrity": "sha512-OQDg6SqvFSsc9A0ej6SKINWrpJiNonRIniYondK2ViKhB06i3c0s+76XUft71iqBEe9S1OKsHwPAjfHnuvnCig==",
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.10.4.tgz",
+          "integrity": "sha512-ZCjD27cGJFUB6nmCB1Enki3r+L5kJveX9pq1SvAUKoICy6CZ9yD8xO086YXdYhvNjBdnekm4ZnaP5yC8Cs/1tA==",
           "requires": {
-            "@babel/code-frame": "^7.10.1",
-            "@babel/parser": "^7.10.1",
-            "@babel/types": "^7.10.1"
+            "@babel/code-frame": "^7.10.4",
+            "@babel/parser": "^7.10.4",
+            "@babel/types": "^7.10.4"
           }
         },
         "@babel/traverse": {
-          "version": "7.10.1",
-          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.10.1.tgz",
-          "integrity": "sha512-C/cTuXeKt85K+p08jN6vMDz8vSV0vZcI0wmQ36o6mjbuo++kPMdpOYw23W2XH04dbRt9/nMEfA4W3eR21CD+TQ==",
+          "version": "7.11.0",
+          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.11.0.tgz",
+          "integrity": "sha512-ZB2V+LskoWKNpMq6E5UUCrjtDUh5IOTAyIl0dTjIEoXum/iKWkoIEKIRDnUucO6f+2FzNkE0oD4RLKoPIufDtg==",
           "requires": {
-            "@babel/code-frame": "^7.10.1",
-            "@babel/generator": "^7.10.1",
-            "@babel/helper-function-name": "^7.10.1",
-            "@babel/helper-split-export-declaration": "^7.10.1",
-            "@babel/parser": "^7.10.1",
-            "@babel/types": "^7.10.1",
+            "@babel/code-frame": "^7.10.4",
+            "@babel/generator": "^7.11.0",
+            "@babel/helper-function-name": "^7.10.4",
+            "@babel/helper-split-export-declaration": "^7.11.0",
+            "@babel/parser": "^7.11.0",
+            "@babel/types": "^7.11.0",
             "debug": "^4.1.0",
             "globals": "^11.1.0",
-            "lodash": "^4.17.13"
+            "lodash": "^4.17.19"
           }
         },
         "@babel/types": {
-          "version": "7.10.2",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.10.2.tgz",
-          "integrity": "sha512-AD3AwWBSz0AWF0AkCN9VPiWrvldXq+/e3cHa4J89vo4ymjz1XwrBFFVZmkJTsQIPNk+ZVomPSXUJqq8yyjZsng==",
+          "version": "7.11.0",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.11.0.tgz",
+          "integrity": "sha512-O53yME4ZZI0jO1EVGtF1ePGl0LHirG4P1ibcD80XyzZcKhcMFeCXmh4Xb1ifGBIV233Qg12x4rBfQgA+tmOukA==",
           "requires": {
-            "@babel/helper-validator-identifier": "^7.10.1",
-            "lodash": "^4.17.13",
+            "@babel/helper-validator-identifier": "^7.10.4",
+            "lodash": "^4.17.19",
             "to-fast-properties": "^2.0.0"
           }
+        },
+        "lodash": {
+          "version": "4.17.20",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
         }
       }
     },
@@ -1253,26 +1344,33 @@
       }
     },
     "@babel/plugin-syntax-class-properties": {
-      "version": "7.10.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.10.1.tgz",
-      "integrity": "sha512-Gf2Yx/iRs1JREDtVZ56OrjjgFHCaldpTnuy9BHla10qyVT3YkIIGEtoDWhyop0ksu1GvNjHIoYRBqm3zoR1jyQ==",
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.10.4.tgz",
+      "integrity": "sha512-GCSBF7iUle6rNugfURwNmCGG3Z/2+opxAMLs1nND4bhEG5PuxTIggDBoeYYSujAlLtsupzOHYJQgPS3pivwXIA==",
       "requires": {
-        "@babel/helper-plugin-utils": "^7.10.1"
+        "@babel/helper-plugin-utils": "^7.10.4"
       },
       "dependencies": {
         "@babel/helper-plugin-utils": {
-          "version": "7.10.1",
-          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.1.tgz",
-          "integrity": "sha512-fvoGeXt0bJc7VMWZGCAEBEMo/HAjW2mP8apF5eXK0wSqwLAVHAISCWRoLMBMUs2kqeaG77jltVqu4Hn8Egl3nA=="
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.4.tgz",
+          "integrity": "sha512-O4KCvQA6lLiMU9l2eawBPMf1xPP8xPfB3iEQw150hOVTqj/rfXz0ThTb4HEzqQfs2Bmo5Ay8BzxfzVtBrr9dVg=="
         }
       }
     },
     "@babel/plugin-syntax-decorators": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-decorators/-/plugin-syntax-decorators-7.8.3.tgz",
-      "integrity": "sha512-8Hg4dNNT9/LcA1zQlfwuKR8BUc/if7Q7NkTam9sGTcJphLwpf2g4S42uhspQrIrR+dpzE0dtTqBVFoHl8GtnnQ==",
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-decorators/-/plugin-syntax-decorators-7.10.4.tgz",
+      "integrity": "sha512-2NaoC6fAk2VMdhY1eerkfHV+lVYC1u8b+jmRJISqANCJlTxYy19HGdIkkQtix2UtkcPuPu+IlDgrVseZnU03bw==",
       "requires": {
-        "@babel/helper-plugin-utils": "^7.8.3"
+        "@babel/helper-plugin-utils": "^7.10.4"
+      },
+      "dependencies": {
+        "@babel/helper-plugin-utils": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.4.tgz",
+          "integrity": "sha512-O4KCvQA6lLiMU9l2eawBPMf1xPP8xPfB3iEQw150hOVTqj/rfXz0ThTb4HEzqQfs2Bmo5Ay8BzxfzVtBrr9dVg=="
+        }
       }
     },
     "@babel/plugin-syntax-dynamic-import": {
@@ -1323,17 +1421,17 @@
       }
     },
     "@babel/plugin-syntax-numeric-separator": {
-      "version": "7.10.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-numeric-separator/-/plugin-syntax-numeric-separator-7.10.1.tgz",
-      "integrity": "sha512-uTd0OsHrpe3tH5gRPTxG8Voh99/WCU78vIm5NMRYPAqC8lR4vajt6KkCAknCHrx24vkPdd/05yfdGSB4EIY2mg==",
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-numeric-separator/-/plugin-syntax-numeric-separator-7.10.4.tgz",
+      "integrity": "sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==",
       "requires": {
-        "@babel/helper-plugin-utils": "^7.10.1"
+        "@babel/helper-plugin-utils": "^7.10.4"
       },
       "dependencies": {
         "@babel/helper-plugin-utils": {
-          "version": "7.10.1",
-          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.1.tgz",
-          "integrity": "sha512-fvoGeXt0bJc7VMWZGCAEBEMo/HAjW2mP8apF5eXK0wSqwLAVHAISCWRoLMBMUs2kqeaG77jltVqu4Hn8Egl3nA=="
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.4.tgz",
+          "integrity": "sha512-O4KCvQA6lLiMU9l2eawBPMf1xPP8xPfB3iEQw150hOVTqj/rfXz0ThTb4HEzqQfs2Bmo5Ay8BzxfzVtBrr9dVg=="
         }
       }
     },
@@ -1538,11 +1636,6 @@
             "@babel/types": "^7.11.0"
           }
         },
-        "@babel/helper-validator-identifier": {
-          "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
-          "integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw=="
-        },
         "@babel/highlight": {
           "version": "7.10.4",
           "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
@@ -1726,11 +1819,6 @@
           "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.4.tgz",
           "integrity": "sha512-O4KCvQA6lLiMU9l2eawBPMf1xPP8xPfB3iEQw150hOVTqj/rfXz0ThTb4HEzqQfs2Bmo5Ay8BzxfzVtBrr9dVg=="
         },
-        "@babel/helper-validator-identifier": {
-          "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
-          "integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw=="
-        },
         "@babel/highlight": {
           "version": "7.10.4",
           "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
@@ -1872,14 +1960,6 @@
         }
       }
     },
-    "@babel/plugin-transform-named-capturing-groups-regex": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.8.3.tgz",
-      "integrity": "sha512-f+tF/8UVPU86TrCb06JoPWIdDpTNSGGcAtaD9mLP0aYGA0OS0j7j7DHJR0GTFrUZPUU6loZhbsVZgTh0N+Qdnw==",
-      "requires": {
-        "@babel/helper-create-regexp-features-plugin": "^7.8.3"
-      }
-    },
     "@babel/plugin-transform-new-target": {
       "version": "7.10.4",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.10.4.tgz",
@@ -1997,11 +2077,6 @@
             "@babel/types": "^7.11.0"
           }
         },
-        "@babel/helper-validator-identifier": {
-          "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
-          "integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw=="
-        },
         "@babel/highlight": {
           "version": "7.10.4",
           "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
@@ -2082,11 +2157,6 @@
           "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.4.tgz",
           "integrity": "sha512-O4KCvQA6lLiMU9l2eawBPMf1xPP8xPfB3iEQw150hOVTqj/rfXz0ThTb4HEzqQfs2Bmo5Ay8BzxfzVtBrr9dVg=="
         },
-        "@babel/helper-validator-identifier": {
-          "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
-          "integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw=="
-        },
         "@babel/types": {
           "version": "7.11.0",
           "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.11.0.tgz",
@@ -2125,6 +2195,16 @@
       "integrity": "sha512-3thAHwtor39A7C04XucbMg17RcZ3Qppfxr22wYzZNcVIkPHfpM9J0SO8zuCV6SZa265kxBJSrfKTvDCYqBFXGw==",
       "requires": {
         "regenerator-transform": "^0.14.2"
+      },
+      "dependencies": {
+        "regenerator-transform": {
+          "version": "0.14.5",
+          "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.14.5.tgz",
+          "integrity": "sha512-eOf6vka5IO151Jfsw2NO9WpGX58W6wWmefK3I1zEGr0lOD0u8rwPaNqQL1aRxUaxLeKO3ArNh3VYg1KbaD+FFw==",
+          "requires": {
+            "@babel/runtime": "^7.8.4"
+          }
+        }
       }
     },
     "@babel/plugin-transform-reserved-words": {
@@ -2262,17 +2342,17 @@
       }
     },
     "@babel/plugin-transform-unicode-escapes": {
-      "version": "7.10.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.10.1.tgz",
-      "integrity": "sha512-zZ0Poh/yy1d4jeDWpx/mNwbKJVwUYJX73q+gyh4bwtG0/iUlzdEu0sLMda8yuDFS6LBQlT/ST1SJAR6zYwXWgw==",
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.10.4.tgz",
+      "integrity": "sha512-y5XJ9waMti2J+e7ij20e+aH+fho7Wb7W8rNuu72aKRwCHFqQdhkdU2lo3uZ9tQuboEJcUFayXdARhcxLQ3+6Fg==",
       "requires": {
-        "@babel/helper-plugin-utils": "^7.10.1"
+        "@babel/helper-plugin-utils": "^7.10.4"
       },
       "dependencies": {
         "@babel/helper-plugin-utils": {
-          "version": "7.10.1",
-          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.1.tgz",
-          "integrity": "sha512-fvoGeXt0bJc7VMWZGCAEBEMo/HAjW2mP8apF5eXK0wSqwLAVHAISCWRoLMBMUs2kqeaG77jltVqu4Hn8Egl3nA=="
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.4.tgz",
+          "integrity": "sha512-O4KCvQA6lLiMU9l2eawBPMf1xPP8xPfB3iEQw150hOVTqj/rfXz0ThTb4HEzqQfs2Bmo5Ay8BzxfzVtBrr9dVg=="
         }
       }
     },
@@ -2355,12 +2435,12 @@
       }
     },
     "@babel/polyfill": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@babel/polyfill/-/polyfill-7.8.3.tgz",
-      "integrity": "sha512-0QEgn2zkCzqGIkSWWAEmvxD7e00Nm9asTtQvi7HdlYvMhjy/J38V/1Y9ode0zEJeIuxAI0uftiAzqc7nVeWUGg==",
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/polyfill/-/polyfill-7.10.4.tgz",
+      "integrity": "sha512-8BYcnVqQ5kMD2HXoHInBH7H1b/uP3KdnwCYXOqFnXqguOyuu443WXusbIUbWEfY3Z0Txk0M1uG/8YuAMhNl6zg==",
       "requires": {
         "core-js": "^2.6.5",
-        "regenerator-runtime": "^0.13.2"
+        "regenerator-runtime": "^0.13.4"
       }
     },
     "@babel/preset-env": {
@@ -2545,11 +2625,6 @@
             "@babel/types": "^7.11.0"
           }
         },
-        "@babel/helper-validator-identifier": {
-          "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
-          "integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw=="
-        },
         "@babel/highlight": {
           "version": "7.10.4",
           "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
@@ -2574,46 +2649,12 @@
             "@babel/helper-plugin-utils": "^7.10.4"
           }
         },
-        "@babel/plugin-proposal-numeric-separator": {
-          "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-numeric-separator/-/plugin-proposal-numeric-separator-7.10.4.tgz",
-          "integrity": "sha512-73/G7QoRoeNkLZFxsoCCvlg4ezE4eM+57PnOqgaPOozd5myfj7p0muD1mRVJvbUWbOzD+q3No2bWbaKy+DJ8DA==",
-          "requires": {
-            "@babel/helper-plugin-utils": "^7.10.4",
-            "@babel/plugin-syntax-numeric-separator": "^7.10.4"
-          }
-        },
-        "@babel/plugin-proposal-private-methods": {
-          "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-methods/-/plugin-proposal-private-methods-7.10.4.tgz",
-          "integrity": "sha512-wh5GJleuI8k3emgTg5KkJK6kHNsGEr0uBTDBuQUBJwckk9xs1ez79ioheEVVxMLyPscB0LfkbVHslQqIzWV6Bw==",
-          "requires": {
-            "@babel/helper-create-class-features-plugin": "^7.10.4",
-            "@babel/helper-plugin-utils": "^7.10.4"
-          }
-        },
         "@babel/plugin-proposal-unicode-property-regex": {
           "version": "7.10.4",
           "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.10.4.tgz",
           "integrity": "sha512-H+3fOgPnEXFL9zGYtKQe4IDOPKYlZdF1kqFDQRRb8PK4B8af1vAGK04tF5iQAAsui+mHNBQSAtd2/ndEDe9wuA==",
           "requires": {
             "@babel/helper-create-regexp-features-plugin": "^7.10.4",
-            "@babel/helper-plugin-utils": "^7.10.4"
-          }
-        },
-        "@babel/plugin-syntax-class-properties": {
-          "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.10.4.tgz",
-          "integrity": "sha512-GCSBF7iUle6rNugfURwNmCGG3Z/2+opxAMLs1nND4bhEG5PuxTIggDBoeYYSujAlLtsupzOHYJQgPS3pivwXIA==",
-          "requires": {
-            "@babel/helper-plugin-utils": "^7.10.4"
-          }
-        },
-        "@babel/plugin-syntax-numeric-separator": {
-          "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-numeric-separator/-/plugin-syntax-numeric-separator-7.10.4.tgz",
-          "integrity": "sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==",
-          "requires": {
             "@babel/helper-plugin-utils": "^7.10.4"
           }
         },
@@ -2632,14 +2673,6 @@
           "integrity": "sha512-V6LuOnD31kTkxQPhKiVYzYC/Jgdq53irJC/xBSmqcNcqFGV+PER4l6rU5SH2Vl7bH9mLDHcc0+l9HUOe4RNGKA==",
           "requires": {
             "@babel/helper-create-regexp-features-plugin": "^7.10.4"
-          }
-        },
-        "@babel/plugin-transform-unicode-escapes": {
-          "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.10.4.tgz",
-          "integrity": "sha512-y5XJ9waMti2J+e7ij20e+aH+fho7Wb7W8rNuu72aKRwCHFqQdhkdU2lo3uZ9tQuboEJcUFayXdARhcxLQ3+6Fg==",
-          "requires": {
-            "@babel/helper-plugin-utils": "^7.10.4"
           }
         },
         "@babel/template": {
@@ -2693,11 +2726,6 @@
           "version": "1.0.30001117",
           "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001117.tgz",
           "integrity": "sha512-4tY0Fatzdx59kYjQs+bNxUwZB03ZEBgVmJ1UkFPz/Q8OLiUUbjct2EdpnXj0fvFTPej2EkbPIG0w8BWsjAyk1Q=="
-        },
-        "electron-to-chromium": {
-          "version": "1.3.545",
-          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.545.tgz",
-          "integrity": "sha512-+0R/i17u5E1cwF3g0W8Niq3UUKTUMyyT4kLkutZUHG8mDNvFsAckK3HIanzGVtixe3b6rknD8k7gHiR6nKFkgg=="
         },
         "lodash": {
           "version": "4.17.20",
@@ -2833,7 +2861,8 @@
     "@ember/edition-utils": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@ember/edition-utils/-/edition-utils-1.2.0.tgz",
-      "integrity": "sha512-VmVq/8saCaPdesQmftPqbFtxJWrzxNGSQ+e8x8LLe3Hjm36pJ04Q8LeORGZkAeOhldoUX9seLGmSaHeXkIqoog=="
+      "integrity": "sha512-VmVq/8saCaPdesQmftPqbFtxJWrzxNGSQ+e8x8LLe3Hjm36pJ04Q8LeORGZkAeOhldoUX9seLGmSaHeXkIqoog==",
+      "dev": true
     },
     "@ember/optional-features": {
       "version": "1.3.0",
@@ -2924,6 +2953,53 @@
         "ember-cli-babel": "^7.7.3",
         "ember-cli-htmlbars-inline-precompile": "^2.1.0",
         "ember-test-waiters": "^1.1.1"
+      },
+      "dependencies": {
+        "broccoli-funnel": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-2.0.2.tgz",
+          "integrity": "sha512-/vDTqtv7ipjEZQOVqO4vGDVAOZyuYzQ/EgGoyewfOgh1M7IQAToBKZI0oAQPgMBeFPPlIbfMuAngk+ohPBuaHQ==",
+          "dev": true,
+          "requires": {
+            "array-equal": "^1.0.0",
+            "blank-object": "^1.0.1",
+            "broccoli-plugin": "^1.3.0",
+            "debug": "^2.2.0",
+            "fast-ordered-set": "^1.0.0",
+            "fs-tree-diff": "^0.5.3",
+            "heimdalljs": "^0.2.0",
+            "minimatch": "^3.0.0",
+            "mkdirp": "^0.5.0",
+            "path-posix": "^1.0.0",
+            "rimraf": "^2.4.3",
+            "symlink-or-copy": "^1.0.0",
+            "walk-sync": "^0.3.1"
+          }
+        },
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        },
+        "rimraf": {
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        }
       }
     },
     "@embroider/core": {
@@ -3043,6 +3119,12 @@
             "@babel/helper-plugin-utils": "^7.0.0",
             "@babel/plugin-syntax-typescript": "^7.2.0"
           }
+        },
+        "@glimmer/di": {
+          "version": "0.1.11",
+          "resolved": "https://registry.npmjs.org/@glimmer/di/-/di-0.1.11.tgz",
+          "integrity": "sha1-poeMB6E6LCx2/N5ZilyXY3v8QoA=",
+          "dev": true
         },
         "broccoli-file-creator": {
           "version": "2.1.1",
@@ -3164,6 +3246,15 @@
             "path-key": "^3.0.0"
           }
         },
+        "onetime": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+          "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+          "dev": true,
+          "requires": {
+            "mimic-fn": "^2.1.0"
+          }
+        },
         "p-finally": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-2.0.1.tgz",
@@ -3219,12 +3310,6 @@
           }
         }
       }
-    },
-    "@glimmer/di": {
-      "version": "0.1.11",
-      "resolved": "https://registry.npmjs.org/@glimmer/di/-/di-0.1.11.tgz",
-      "integrity": "sha1-poeMB6E6LCx2/N5ZilyXY3v8QoA=",
-      "dev": true
     },
     "@glimmer/env": {
       "version": "0.1.7",
@@ -3345,10 +3430,43 @@
         "fastq": "^1.6.0"
       }
     },
+    "@simple-dom/document": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@simple-dom/document/-/document-1.4.0.tgz",
+      "integrity": "sha512-/RUeVH4kuD3rzo5/91+h4Z1meLSLP66eXqpVAw/4aZmYozkeqUkMprq0znL4psX/adEed5cBgiNJcfMz/eKZLg==",
+      "dev": true,
+      "requires": {
+        "@simple-dom/interface": "^1.4.0"
+      }
+    },
     "@simple-dom/interface": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/@simple-dom/interface/-/interface-1.4.0.tgz",
       "integrity": "sha512-l5qumKFWU0S+4ZzMaLXFU8tQZsicHEMEyAxI5kDFGhJsRqDwe0a7/iPA/GdxlGyDKseQQAgIz5kzU7eXTrlSpA==",
+      "dev": true
+    },
+    "@simple-dom/parser": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@simple-dom/parser/-/parser-1.4.0.tgz",
+      "integrity": "sha512-TNjDkOehueRIKr1df416qk9ELj+qWuVVJNIT25y1aZg3pQvxv4UPGrgaDFte7dsWBTbF3V8NYPNQ5FDUZQ8Wlg==",
+      "dev": true,
+      "requires": {
+        "@simple-dom/interface": "^1.4.0"
+      }
+    },
+    "@simple-dom/serializer": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@simple-dom/serializer/-/serializer-1.4.0.tgz",
+      "integrity": "sha512-mI1yRahsVs8atXLiQksineDsFEFqeG7RHwnnBTDOK6inbzl4tZQgjR+Z7edjgIJq5j5RhZvwPI6EuCji9B3eQw==",
+      "dev": true,
+      "requires": {
+        "@simple-dom/interface": "^1.4.0"
+      }
+    },
+    "@simple-dom/void-map": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@simple-dom/void-map/-/void-map-1.4.0.tgz",
+      "integrity": "sha512-VDhLEyVCbuhOBBgHol9ShzIv9O8UCzdXeH4FoXu2DOcu/nnvTjLTck+BgXsCLv5ynDiUdoqsREEVFnoyPpFKVw==",
       "dev": true
     },
     "@sindresorhus/is": {
@@ -3406,11 +3524,6 @@
         "@types/node": "*"
       }
     },
-    "@types/events": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.0.tgz",
-      "integrity": "sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g=="
-    },
     "@types/express": {
       "version": "4.17.7",
       "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.7.tgz",
@@ -3443,11 +3556,10 @@
       }
     },
     "@types/glob": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.1.tgz",
-      "integrity": "sha512-1Bh06cbWJUHMC97acuD6UMG29nMt0Aqz1vF3guLfG+kHHJhy3AyohZFFxYk2f7Q1SQIrNwvncxAE0N/9s70F2w==",
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.3.tgz",
+      "integrity": "sha512-SEYeGAIQIQX8NN6LDKprLjbrd5dARM5EXsd8GI/A5l0apYI1fGMWgPHSe4ZKL4eozlAyI+doUE9XbYS4xCkQ1w==",
       "requires": {
-        "@types/events": "*",
         "@types/minimatch": "*",
         "@types/node": "*"
       }
@@ -3476,9 +3588,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "13.7.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.7.0.tgz",
-      "integrity": "sha512-GnZbirvmqZUzMgkFn70c74OQpTTUcCzlhQliTzYjQMqg+hVKcDnxdL19Ne3UdYzdMA/+W3eb646FWn/ZaT1NfQ=="
+      "version": "14.6.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.6.0.tgz",
+      "integrity": "sha512-mikldZQitV94akrc4sCcSjtJfsTKt4p+e/s0AGscVA6XArQ9kFclP+ZiYUMnq987rc6QlYxXv/EivqlfSLxpKA=="
     },
     "@types/normalize-package-data": {
       "version": "2.4.0",
@@ -3505,9 +3617,9 @@
       "dev": true
     },
     "@types/rimraf": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@types/rimraf/-/rimraf-2.0.3.tgz",
-      "integrity": "sha512-dZfyfL/u9l/oi984hEXdmAjX3JHry7TLWw43u1HQ8HhPv6KtfxnrZ3T/bleJ0GEvnk9t5sM7eePkgMqz3yBcGg==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@types/rimraf/-/rimraf-2.0.4.tgz",
+      "integrity": "sha512-8gBudvllD2A/c0CcEX/BivIDorHFt5UI5m46TsNj8DjWCCTTZT74kEe4g+QsY7P/B9WdO98d82zZgXO/RQzu2Q==",
       "requires": {
         "@types/glob": "*",
         "@types/node": "*"
@@ -3923,7 +4035,6 @@
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.1.tgz",
       "integrity": "sha512-JWF7ocqNrp8u9oqpgV+wH5ftbt+cfvv+PTjOvKLT3AdYly/LmORARfEVT1iyjwN+4MqE5UmVKoAdIBqeoCHgLA==",
-      "dev": true,
       "requires": {
         "type-fest": "^0.11.0"
       },
@@ -3931,8 +4042,7 @@
         "type-fest": {
           "version": "0.11.0",
           "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.11.0.tgz",
-          "integrity": "sha512-OdjXJxnCN1AvyLSzeKIgXTXxV+99ZuXl3Hpo9XpJAv9MBcHrrJOQ5kV7ypXOuQie+AmWG25hLbiKdwYTifzcfQ==",
-          "dev": true
+          "integrity": "sha512-OdjXJxnCN1AvyLSzeKIgXTXxV+99ZuXl3Hpo9XpJAv9MBcHrrJOQ5kV7ypXOuQie+AmWG25hLbiKdwYTifzcfQ=="
         }
       }
     },
@@ -3969,17 +4079,6 @@
       "resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.2.1.tgz",
       "integrity": "sha1-vgiVmQl7dKXJxKhKDNvNtivYeu8=",
       "dev": true
-    },
-    "anymatch": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
-      "integrity": "sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "normalize-path": "^3.0.0",
-        "picomatch": "^2.0.4"
-      }
     },
     "append-transform": {
       "version": "1.0.0",
@@ -4655,11 +4754,18 @@
       }
     },
     "babel-plugin-ember-modules-api-polyfill": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-ember-modules-api-polyfill/-/babel-plugin-ember-modules-api-polyfill-2.12.0.tgz",
-      "integrity": "sha512-ZQU4quX0TJ1yYyosPy5PFigKdCFEVHJ6H0b3hwjxekIP9CDwzk0OhQuKhCOPti+d52VWjjCjxu2BrXEih29mFw==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-ember-modules-api-polyfill/-/babel-plugin-ember-modules-api-polyfill-3.1.1.tgz",
+      "integrity": "sha512-hRTnr59fJ6cIiSiSgQLM9QRiVv/RrBAYRYggCPQDj4dvYhOWZeoX6e+1jFY1qC3tJnSDuMWu3OrDciSIi1MJ0A==",
       "requires": {
-        "ember-rfc176-data": "^0.3.12"
+        "ember-rfc176-data": "^0.3.15"
+      },
+      "dependencies": {
+        "ember-rfc176-data": {
+          "version": "0.3.15",
+          "resolved": "https://registry.npmjs.org/ember-rfc176-data/-/ember-rfc176-data-0.3.15.tgz",
+          "integrity": "sha512-GPKa7zRDBblRy0orxTXt5yrpp/Pf5CkuRFSIR8qMFDww0CqCKjCRwdZnWYzCM4kAEfZnXRIDDefe1tBaFw7v7w=="
+        }
       }
     },
     "babel-plugin-filter-imports": {
@@ -5515,52 +5621,16 @@
         "which": "^2.0.1"
       },
       "dependencies": {
-        "ansi-escapes": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.0.tgz",
-          "integrity": "sha512-EiYhwo0v255HUL6eDyuLrXEkTi7WwVCLAw+SeOQ7M7qdun1z1pum4DEm/nuqIVbPvi9RPPc9k9LbyBv6H0DwVg==",
-          "dev": true,
-          "requires": {
-            "type-fest": "^0.8.1"
-          }
-        },
-        "ansi-regex": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
-          "dev": true
-        },
-        "chardet": {
-          "version": "0.7.0",
-          "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
-          "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
-          "dev": true
-        },
-        "cli-cursor": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
-          "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
-          "dev": true,
-          "requires": {
-            "restore-cursor": "^3.1.0"
-          }
-        },
         "cross-spawn": {
-          "version": "7.0.1",
-          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.1.tgz",
-          "integrity": "sha512-u7v4o84SwFpD32Z8IIcPZ6z1/ie24O6RU3RbtL5Y316l3KuHVPx9ItBgWQ6VlfAFnRnTtMUrsQ9MUUTuEZjogg==",
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+          "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
           "dev": true,
           "requires": {
             "path-key": "^3.1.0",
             "shebang-command": "^2.0.0",
             "which": "^2.0.1"
           }
-        },
-        "emoji-regex": {
-          "version": "8.0.0",
-          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-          "dev": true
         },
         "execa": {
           "version": "3.4.0",
@@ -5580,81 +5650,23 @@
             "strip-final-newline": "^2.0.0"
           }
         },
-        "external-editor": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
-          "integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
-          "dev": true,
-          "requires": {
-            "chardet": "^0.7.0",
-            "iconv-lite": "^0.4.24",
-            "tmp": "^0.0.33"
-          },
-          "dependencies": {
-            "tmp": {
-              "version": "0.0.33",
-              "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-              "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-              "dev": true,
-              "requires": {
-                "os-tmpdir": "~1.0.2"
-              }
-            }
-          }
-        },
-        "figures": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/figures/-/figures-3.1.0.tgz",
-          "integrity": "sha512-ravh8VRXqHuMvZt/d8GblBeqDMkdJMBdv/2KntFH+ra5MXkO7nxNKpzQ3n6QD/2da1kH0aWmNISdvhM7gl2gVg==",
-          "dev": true,
-          "requires": {
-            "escape-string-regexp": "^1.0.5"
-          }
-        },
         "get-stream": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.1.0.tgz",
-          "integrity": "sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==",
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+          "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
           "dev": true,
           "requires": {
             "pump": "^3.0.0"
           }
         },
         "hosted-git-info": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-3.0.2.tgz",
-          "integrity": "sha512-ezZMWtHXm7Eb7Rq4Mwnx2vs79WUx2QmRg3+ZqeGroKzfDO+EprOcgRPYghsOP9JuYBfK18VojmRTGCg8Ma+ktw==",
+          "version": "3.0.5",
+          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-3.0.5.tgz",
+          "integrity": "sha512-i4dpK6xj9BIpVOTboXIlKG9+8HMKggcrMX7WA24xZtKwX0TPelq/rbaS5rCKeNX8sJXZJGdSxpnEGtta+wismQ==",
           "dev": true,
           "requires": {
-            "lru-cache": "^5.1.1"
+            "lru-cache": "^6.0.0"
           }
-        },
-        "inquirer": {
-          "version": "7.0.4",
-          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.0.4.tgz",
-          "integrity": "sha512-Bu5Td5+j11sCkqfqmUTiwv+tWisMtP0L7Q8WrqA2C/BbBhy1YTdFrvjjlrKq8oagA/tLQBski2Gcx/Sqyi2qSQ==",
-          "dev": true,
-          "requires": {
-            "ansi-escapes": "^4.2.1",
-            "chalk": "^2.4.2",
-            "cli-cursor": "^3.1.0",
-            "cli-width": "^2.0.0",
-            "external-editor": "^3.0.3",
-            "figures": "^3.0.0",
-            "lodash": "^4.17.15",
-            "mute-stream": "0.0.8",
-            "run-async": "^2.2.0",
-            "rxjs": "^6.5.3",
-            "string-width": "^4.1.0",
-            "strip-ansi": "^5.1.0",
-            "through": "^2.3.6"
-          }
-        },
-        "is-fullwidth-code-point": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-          "dev": true
         },
         "is-stream": {
           "version": "2.0.0",
@@ -5663,25 +5675,13 @@
           "dev": true
         },
         "lru-cache": {
-          "version": "5.1.1",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-          "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
           "dev": true,
           "requires": {
-            "yallist": "^3.0.2"
+            "yallist": "^4.0.0"
           }
-        },
-        "mimic-fn": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-          "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
-          "dev": true
-        },
-        "mute-stream": {
-          "version": "0.0.8",
-          "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
-          "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
-          "dev": true
         },
         "npm-package-arg": {
           "version": "7.0.0",
@@ -5713,9 +5713,9 @@
           }
         },
         "onetime": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.0.tgz",
-          "integrity": "sha512-5NcSkPHhwTVFIQN+TUqXoS5+dlElHXdpAWu9I0HP20YOtIi+aZ0Ct82jdlILDxjLEAWwvm+qj1m6aEtsDVmm6Q==",
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+          "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
           "dev": true,
           "requires": {
             "mimic-fn": "^2.1.0"
@@ -5732,16 +5732,6 @@
           "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
           "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
           "dev": true
-        },
-        "restore-cursor": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
-          "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
-          "dev": true,
-          "requires": {
-            "onetime": "^5.1.0",
-            "signal-exit": "^3.0.2"
-          }
         },
         "semver": {
           "version": "6.3.0",
@@ -5763,45 +5753,6 @@
           "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
           "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
           "dev": true
-        },
-        "string-width": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
-          "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
-          "dev": true,
-          "requires": {
-            "emoji-regex": "^8.0.0",
-            "is-fullwidth-code-point": "^3.0.0",
-            "strip-ansi": "^6.0.0"
-          },
-          "dependencies": {
-            "strip-ansi": {
-              "version": "6.0.0",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-              "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
-              "dev": true,
-              "requires": {
-                "ansi-regex": "^5.0.0"
-              }
-            }
-          }
-        },
-        "strip-ansi": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^4.1.0"
-          },
-          "dependencies": {
-            "ansi-regex": {
-              "version": "4.1.0",
-              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-              "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-              "dev": true
-            }
-          }
         },
         "tmp": {
           "version": "0.1.0",
@@ -5831,6 +5782,12 @@
           "requires": {
             "isexe": "^2.0.0"
           }
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+          "dev": true
         }
       }
     },
@@ -6060,6 +6017,12 @@
         "watch-detector": "^1.0.0"
       },
       "dependencies": {
+        "broccoli-node-info": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/broccoli-node-info/-/broccoli-node-info-2.1.0.tgz",
+          "integrity": "sha512-l6qDuboJThHfRVVWQVaTs++bFdrFTP0gJXgsWenczc1PavRVUmL1Eyb2swTAXXMpDOnr2zhNOBLx4w9AxkqbPQ==",
+          "dev": true
+        },
         "broccoli-source": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/broccoli-source/-/broccoli-source-3.0.0.tgz",
@@ -6208,21 +6171,213 @@
       }
     },
     "broccoli-babel-transpiler": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/broccoli-babel-transpiler/-/broccoli-babel-transpiler-7.4.0.tgz",
-      "integrity": "sha512-DzPXQr1C+zOgzXG40wqPjtjSSa6wRKb+Ls45Qtq7Pn+GxL3/jIvQOBZi0/irZ5dlYVbRMEZiUnaIBIOha2ygIw==",
+      "version": "7.7.0",
+      "resolved": "https://registry.npmjs.org/broccoli-babel-transpiler/-/broccoli-babel-transpiler-7.7.0.tgz",
+      "integrity": "sha512-U8Cmnv0/AcQKehiIVi6UDzqq3jqhAEbY9CvOW5vdeNRmYhFpK6bXPmVczS/nUz5g4KsPc/FdnC3zbU6yVf4e7w==",
       "requires": {
-        "@babel/core": "^7.8.3",
-        "@babel/polyfill": "^7.8.3",
+        "@babel/core": "^7.11.0",
+        "@babel/polyfill": "^7.10.4",
         "broccoli-funnel": "^2.0.2",
         "broccoli-merge-trees": "^3.0.2",
         "broccoli-persistent-filter": "^2.2.1",
         "clone": "^2.1.2",
         "hash-for-dep": "^1.4.7",
+        "heimdalljs": "^0.2.1",
         "heimdalljs-logger": "^0.1.9",
         "json-stable-stringify": "^1.0.1",
         "rsvp": "^4.8.4",
         "workerpool": "^3.1.1"
+      },
+      "dependencies": {
+        "@babel/code-frame": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
+          "integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
+          "requires": {
+            "@babel/highlight": "^7.10.4"
+          }
+        },
+        "@babel/core": {
+          "version": "7.11.4",
+          "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.11.4.tgz",
+          "integrity": "sha512-5deljj5HlqRXN+5oJTY7Zs37iH3z3b++KjiKtIsJy1NrjOOVSEaJHEetLBhyu0aQOSNNZ/0IuEAan9GzRuDXHg==",
+          "requires": {
+            "@babel/code-frame": "^7.10.4",
+            "@babel/generator": "^7.11.4",
+            "@babel/helper-module-transforms": "^7.11.0",
+            "@babel/helpers": "^7.10.4",
+            "@babel/parser": "^7.11.4",
+            "@babel/template": "^7.10.4",
+            "@babel/traverse": "^7.11.0",
+            "@babel/types": "^7.11.0",
+            "convert-source-map": "^1.7.0",
+            "debug": "^4.1.0",
+            "gensync": "^1.0.0-beta.1",
+            "json5": "^2.1.2",
+            "lodash": "^4.17.19",
+            "resolve": "^1.3.2",
+            "semver": "^5.4.1",
+            "source-map": "^0.5.0"
+          }
+        },
+        "@babel/generator": {
+          "version": "7.11.4",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.11.4.tgz",
+          "integrity": "sha512-Rn26vueFx0eOoz7iifCN2UHT6rGtnkSGWSoDRIy8jZN3B91PzeSULbswfLoOWuTuAcNwpG/mxy+uCTDnZ9Mp1g==",
+          "requires": {
+            "@babel/types": "^7.11.0",
+            "jsesc": "^2.5.1",
+            "source-map": "^0.5.0"
+          }
+        },
+        "@babel/helper-function-name": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.10.4.tgz",
+          "integrity": "sha512-YdaSyz1n8gY44EmN7x44zBn9zQ1Ry2Y+3GTA+3vH6Mizke1Vw0aWDM66FOYEPw8//qKkmqOckrGgTYa+6sceqQ==",
+          "requires": {
+            "@babel/helper-get-function-arity": "^7.10.4",
+            "@babel/template": "^7.10.4",
+            "@babel/types": "^7.10.4"
+          }
+        },
+        "@babel/helper-get-function-arity": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.10.4.tgz",
+          "integrity": "sha512-EkN3YDB+SRDgiIUnNgcmiD361ti+AVbL3f3Henf6dqqUyr5dMsorno0lJWJuLhDhkI5sYEpgj6y9kB8AOU1I2A==",
+          "requires": {
+            "@babel/types": "^7.10.4"
+          }
+        },
+        "@babel/helper-split-export-declaration": {
+          "version": "7.11.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.11.0.tgz",
+          "integrity": "sha512-74Vejvp6mHkGE+m+k5vHY93FX2cAtrw1zXrZXRlG4l410Nm9PxfEiVTn1PjDPV5SnmieiueY4AFg2xqhNFuuZg==",
+          "requires": {
+            "@babel/types": "^7.11.0"
+          }
+        },
+        "@babel/helpers": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.10.4.tgz",
+          "integrity": "sha512-L2gX/XeUONeEbI78dXSrJzGdz4GQ+ZTA/aazfUsFaWjSe95kiCuOZ5HsXvkiw3iwF+mFHSRUfJU8t6YavocdXA==",
+          "requires": {
+            "@babel/template": "^7.10.4",
+            "@babel/traverse": "^7.10.4",
+            "@babel/types": "^7.10.4"
+          }
+        },
+        "@babel/highlight": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
+          "integrity": "sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==",
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.10.4",
+            "chalk": "^2.0.0",
+            "js-tokens": "^4.0.0"
+          }
+        },
+        "@babel/parser": {
+          "version": "7.11.4",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.11.4.tgz",
+          "integrity": "sha512-MggwidiH+E9j5Sh8pbrX5sJvMcsqS5o+7iB42M9/k0CD63MjYbdP4nhSh7uB5wnv2/RVzTZFTxzF/kIa5mrCqA=="
+        },
+        "@babel/template": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.10.4.tgz",
+          "integrity": "sha512-ZCjD27cGJFUB6nmCB1Enki3r+L5kJveX9pq1SvAUKoICy6CZ9yD8xO086YXdYhvNjBdnekm4ZnaP5yC8Cs/1tA==",
+          "requires": {
+            "@babel/code-frame": "^7.10.4",
+            "@babel/parser": "^7.10.4",
+            "@babel/types": "^7.10.4"
+          }
+        },
+        "@babel/traverse": {
+          "version": "7.11.0",
+          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.11.0.tgz",
+          "integrity": "sha512-ZB2V+LskoWKNpMq6E5UUCrjtDUh5IOTAyIl0dTjIEoXum/iKWkoIEKIRDnUucO6f+2FzNkE0oD4RLKoPIufDtg==",
+          "requires": {
+            "@babel/code-frame": "^7.10.4",
+            "@babel/generator": "^7.11.0",
+            "@babel/helper-function-name": "^7.10.4",
+            "@babel/helper-split-export-declaration": "^7.11.0",
+            "@babel/parser": "^7.11.0",
+            "@babel/types": "^7.11.0",
+            "debug": "^4.1.0",
+            "globals": "^11.1.0",
+            "lodash": "^4.17.19"
+          }
+        },
+        "@babel/types": {
+          "version": "7.11.0",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.11.0.tgz",
+          "integrity": "sha512-O53yME4ZZI0jO1EVGtF1ePGl0LHirG4P1ibcD80XyzZcKhcMFeCXmh4Xb1ifGBIV233Qg12x4rBfQgA+tmOukA==",
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.10.4",
+            "lodash": "^4.17.19",
+            "to-fast-properties": "^2.0.0"
+          }
+        },
+        "broccoli-funnel": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-2.0.2.tgz",
+          "integrity": "sha512-/vDTqtv7ipjEZQOVqO4vGDVAOZyuYzQ/EgGoyewfOgh1M7IQAToBKZI0oAQPgMBeFPPlIbfMuAngk+ohPBuaHQ==",
+          "requires": {
+            "array-equal": "^1.0.0",
+            "blank-object": "^1.0.1",
+            "broccoli-plugin": "^1.3.0",
+            "debug": "^2.2.0",
+            "fast-ordered-set": "^1.0.0",
+            "fs-tree-diff": "^0.5.3",
+            "heimdalljs": "^0.2.0",
+            "minimatch": "^3.0.0",
+            "mkdirp": "^0.5.0",
+            "path-posix": "^1.0.0",
+            "rimraf": "^2.4.3",
+            "symlink-or-copy": "^1.0.0",
+            "walk-sync": "^0.3.1"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "2.6.9",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+              "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+              "requires": {
+                "ms": "2.0.0"
+              }
+            }
+          }
+        },
+        "json5": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.3.tgz",
+          "integrity": "sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==",
+          "requires": {
+            "minimist": "^1.2.5"
+          }
+        },
+        "lodash": {
+          "version": "4.17.20",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
+        },
+        "minimist": {
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        },
+        "rimraf": {
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        }
       }
     },
     "broccoli-builder": {
@@ -6240,12 +6395,6 @@
         "silent-error": "^1.0.1"
       },
       "dependencies": {
-        "broccoli-node-info": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/broccoli-node-info/-/broccoli-node-info-1.1.0.tgz",
-          "integrity": "sha1-OqLjHgflvbUW3SUhT3xFuhxFlBI=",
-          "dev": true
-        },
         "rimraf": {
           "version": "2.7.1",
           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
@@ -6615,49 +6764,6 @@
         "mkdirp": "^0.5.1"
       }
     },
-    "broccoli-funnel": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-2.0.2.tgz",
-      "integrity": "sha512-/vDTqtv7ipjEZQOVqO4vGDVAOZyuYzQ/EgGoyewfOgh1M7IQAToBKZI0oAQPgMBeFPPlIbfMuAngk+ohPBuaHQ==",
-      "requires": {
-        "array-equal": "^1.0.0",
-        "blank-object": "^1.0.1",
-        "broccoli-plugin": "^1.3.0",
-        "debug": "^2.2.0",
-        "fast-ordered-set": "^1.0.0",
-        "fs-tree-diff": "^0.5.3",
-        "heimdalljs": "^0.2.0",
-        "minimatch": "^3.0.0",
-        "mkdirp": "^0.5.0",
-        "path-posix": "^1.0.0",
-        "rimraf": "^2.4.3",
-        "symlink-or-copy": "^1.0.0",
-        "walk-sync": "^0.3.1"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-        },
-        "rimraf": {
-          "version": "2.7.1",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-          "requires": {
-            "glob": "^7.1.3"
-          }
-        }
-      }
-    },
     "broccoli-funnel-reducer": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/broccoli-funnel-reducer/-/broccoli-funnel-reducer-1.0.0.tgz",
@@ -6754,21 +6860,14 @@
     "broccoli-node-api": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/broccoli-node-api/-/broccoli-node-api-1.7.0.tgz",
-      "integrity": "sha512-QIqLSVJWJUVOhclmkmypJJH9u9s/aWH4+FH6Q6Ju5l+Io4dtwqdPUNmDfw40o6sxhbZHhqGujDJuHTML1wG8Yw=="
-    },
-    "broccoli-node-info": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/broccoli-node-info/-/broccoli-node-info-2.1.0.tgz",
-      "integrity": "sha512-l6qDuboJThHfRVVWQVaTs++bFdrFTP0gJXgsWenczc1PavRVUmL1Eyb2swTAXXMpDOnr2zhNOBLx4w9AxkqbPQ==",
+      "integrity": "sha512-QIqLSVJWJUVOhclmkmypJJH9u9s/aWH4+FH6Q6Ju5l+Io4dtwqdPUNmDfw40o6sxhbZHhqGujDJuHTML1wG8Yw==",
       "dev": true
     },
-    "broccoli-output-wrapper": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/broccoli-output-wrapper/-/broccoli-output-wrapper-2.0.0.tgz",
-      "integrity": "sha512-V/ozejo+snzNf75i/a6iTmp71k+rlvqjE3+jYfimuMwR1tjNNRdtfno+NGNQB2An9bIAeqZnKhMDurAznHAdtA==",
-      "requires": {
-        "heimdalljs-logger": "^0.1.10"
-      }
+    "broccoli-node-info": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/broccoli-node-info/-/broccoli-node-info-1.1.0.tgz",
+      "integrity": "sha1-OqLjHgflvbUW3SUhT3xFuhxFlBI=",
+      "dev": true
     },
     "broccoli-persistent-filter": {
       "version": "2.3.1",
@@ -6913,6 +7012,60 @@
         "walk-sync": "^1.1.3"
       },
       "dependencies": {
+        "broccoli-funnel": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-2.0.2.tgz",
+          "integrity": "sha512-/vDTqtv7ipjEZQOVqO4vGDVAOZyuYzQ/EgGoyewfOgh1M7IQAToBKZI0oAQPgMBeFPPlIbfMuAngk+ohPBuaHQ==",
+          "dev": true,
+          "requires": {
+            "array-equal": "^1.0.0",
+            "blank-object": "^1.0.1",
+            "broccoli-plugin": "^1.3.0",
+            "debug": "^2.2.0",
+            "fast-ordered-set": "^1.0.0",
+            "fs-tree-diff": "^0.5.3",
+            "heimdalljs": "^0.2.0",
+            "minimatch": "^3.0.0",
+            "mkdirp": "^0.5.0",
+            "path-posix": "^1.0.0",
+            "rimraf": "^2.4.3",
+            "symlink-or-copy": "^1.0.0",
+            "walk-sync": "^0.3.1"
+          },
+          "dependencies": {
+            "broccoli-plugin": {
+              "version": "1.3.1",
+              "resolved": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-1.3.1.tgz",
+              "integrity": "sha512-DW8XASZkmorp+q7J4EeDEZz+LoyKLAd2XZULXyD9l4m9/hAKV3vjHmB1kiUshcWAYMgTP1m2i4NnqCE/23h6AQ==",
+              "dev": true,
+              "requires": {
+                "promise-map-series": "^0.2.1",
+                "quick-temp": "^0.1.3",
+                "rimraf": "^2.3.4",
+                "symlink-or-copy": "^1.1.8"
+              }
+            },
+            "debug": {
+              "version": "2.6.9",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+              "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+              "dev": true,
+              "requires": {
+                "ms": "2.0.0"
+              }
+            },
+            "walk-sync": {
+              "version": "0.3.4",
+              "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-0.3.4.tgz",
+              "integrity": "sha512-ttGcuHA/OBnN2pcM6johpYlEms7XpO5/fyKIr48541xXedan4roO8cS1Q2S/zbbjGH/BarYDAMeS2Mi9HE5Tig==",
+              "dev": true,
+              "requires": {
+                "ensure-posix-path": "^1.0.0",
+                "matcher-collection": "^1.0.0"
+              }
+            }
+          }
+        },
         "broccoli-plugin": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-2.1.0.tgz",
@@ -6935,6 +7088,12 @@
             "jsonfile": "^4.0.0",
             "universalify": "^0.1.0"
           }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
         },
         "rimraf": {
           "version": "2.7.1",
@@ -6985,6 +7144,33 @@
           "requires": {
             "@types/minimatch": "^3.0.3",
             "minimatch": "^3.0.2"
+          }
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        },
+        "source-map-support": {
+          "version": "0.5.19",
+          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
+          "integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
+          "dev": true,
+          "requires": {
+            "buffer-from": "^1.0.0",
+            "source-map": "^0.6.0"
+          }
+        },
+        "terser": {
+          "version": "4.8.0",
+          "resolved": "https://registry.npmjs.org/terser/-/terser-4.8.0.tgz",
+          "integrity": "sha512-EAPipTNeWsb/3wLPeup1tVPaXfIaU68xMnVdPafIL1TV05OhASArYyIfFvnvJCNrR2NIOvDVNNTFRa+Re2MWyw==",
+          "dev": true,
+          "requires": {
+            "commander": "^2.20.0",
+            "source-map": "~0.6.1",
+            "source-map-support": "~0.5.12"
           }
         },
         "walk-sync": {
@@ -7197,8 +7383,7 @@
     "builtins": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/builtins/-/builtins-1.0.3.tgz",
-      "integrity": "sha1-y5T662HIaWRR2zZTThQi+U8K7og=",
-      "dev": true
+      "integrity": "sha1-y5T662HIaWRR2zZTThQi+U8K7og="
     },
     "bytes": {
       "version": "3.0.0",
@@ -7232,30 +7417,100 @@
         "unique-filename": "^1.1.1"
       },
       "dependencies": {
-        "lru-cache": {
-          "version": "5.1.1",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-          "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
-          "dev": true,
+        "ansi-escapes": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.0.tgz",
+          "integrity": "sha512-EiYhwo0v255HUL6eDyuLrXEkTi7WwVCLAw+SeOQ7M7qdun1z1pum4DEm/nuqIVbPvi9RPPc9k9LbyBv6H0DwVg==",
           "requires": {
-            "yallist": "^3.0.2"
+            "type-fest": "^0.8.1"
           }
         },
+        "ansi-regex": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
+        },
+        "chardet": {
+          "version": "0.7.0",
+          "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
+          "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA=="
+        },
+        "cli-cursor": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
+          "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw=="
+        },
+        "cross-spawn": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.1.tgz",
+          "integrity": "sha512-u7v4o84SwFpD32Z8IIcPZ6z1/ie24O6RU3RbtL5Y316l3KuHVPx9ItBgWQ6VlfAFnRnTtMUrsQ9MUUTuEZjogg=="
+        },
+        "emoji-regex": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+        },
+        "execa": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-3.4.0.tgz",
+          "integrity": "sha512-r9vdGQk4bmCuK1yKQu1KTwcT2zwfWdbdaXfCtAh+5nU/4fSX+JAb7vZGvI5naJrQlvONrEB20jeruESI69530g==",
+          "requires": {
+            "cross-spawn": "^7.0.0",
+            "get-stream": "^5.0.0",
+            "human-signals": "^1.1.1",
+            "merge-stream": "^2.0.0",
+            "signal-exit": "^3.0.2",
+            "strip-final-newline": "^2.0.0"
+          }
+        },
+        "external-editor": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
+          "integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
+          "requires": {
+            "chardet": "^0.7.0",
+            "iconv-lite": "^0.4.24",
+            "tmp": "^0.0.33"
+          },
+          "dependencies": {
+            "tmp": {
+              "version": "0.0.33",
+              "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+              "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+              "requires": {
+                "os-tmpdir": "~1.0.2"
+              }
+            }
+          }
+        },
+        "figures": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/figures/-/figures-3.1.0.tgz",
+          "integrity": "sha512-ravh8VRXqHuMvZt/d8GblBeqDMkdJMBdv/2KntFH+ra5MXkO7nxNKpzQ3n6QD/2da1kH0aWmNISdvhM7gl2gVg==",
+          "requires": {
+            "escape-string-regexp": "^1.0.5"
+          }
+        },
+        "get-stream": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.1.0.tgz",
+          "integrity": "sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==",
+          "requires": {
+            "pump": "^3.0.0"
+          }
+        },
+        "lowercase-keys": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
+          "integrity": "sha1-TjNms55/VFfjXxMkvfb4jQv8cwY="
+        },
         "minipass": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.1.tgz",
-          "integrity": "sha512-UFqVihv6PQgwj8/yTGvl9kPz7xIAY+R5z6XYjRInD3Gk3qx6QGSD6zEcpeG4Dy/lQnv1J6zv8ejV90hyYIKf3w==",
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.3.tgz",
+          "integrity": "sha512-Mgd2GdMVzY+x3IJ+oHnVM+KG3lA5c8tnabyJKmHSaG2kAGpudxuOf8ToDkhumF7UzME7DecbQE9uOZhNm7PuJg==",
           "dev": true,
           "requires": {
             "yallist": "^4.0.0"
-          },
-          "dependencies": {
-            "yallist": {
-              "version": "4.0.0",
-              "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-              "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-              "dev": true
-            }
           }
         },
         "rimraf": {
@@ -7266,6 +7521,12 @@
           "requires": {
             "glob": "^7.1.3"
           }
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+          "dev": true
         }
       }
     },
@@ -7415,12 +7676,6 @@
         "supports-color": "^5.3.0"
       }
     },
-    "chardet": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
-      "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
-      "dev": true
-    },
     "charm": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/charm/-/charm-1.0.2.tgz",
@@ -7474,14 +7729,27 @@
             "to-regex-range": "^5.0.1"
           }
         },
-        "is-glob": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
-          "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
-          "dev": true,
+        "inquirer": {
+          "version": "7.0.4",
+          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.0.4.tgz",
+          "integrity": "sha512-Bu5Td5+j11sCkqfqmUTiwv+tWisMtP0L7Q8WrqA2C/BbBhy1YTdFrvjjlrKq8oagA/tLQBski2Gcx/Sqyi2qSQ==",
           "requires": {
-            "is-extglob": "^2.1.1"
+            "ansi-escapes": "^4.2.1",
+            "chalk": "^2.4.2",
+            "cli-cursor": "^3.1.0",
+            "cli-width": "^2.0.0",
+            "figures": "^3.0.0",
+            "lodash": "^4.17.15",
+            "mute-stream": "0.0.8",
+            "run-async": "^2.2.0",
+            "rxjs": "^6.5.3",
+            "through": "^2.3.6"
           }
+        },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
         },
         "is-number": {
           "version": "7.0.0",
@@ -7489,11 +7757,80 @@
           "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
           "dev": true
         },
-        "normalize-path": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-          "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-          "dev": true
+        "is-stream": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
+          "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw=="
+        },
+        "lru-cache": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+          "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+          "requires": {
+            "yallist": "^3.0.2"
+          }
+        },
+        "mimic-fn": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+          "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="
+        },
+        "mute-stream": {
+          "version": "0.0.8",
+          "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
+          "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA=="
+        },
+        "npm-package-arg": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-7.0.0.tgz",
+          "integrity": "sha512-xXxr8y5U0kl8dVkz2oK7yZjPBvqM2fwaO5l3Yg13p03v8+E3qQcD0JNhHzjL1vyGgxcKkD0cco+NLR72iuPk3g==",
+          "requires": {
+            "osenv": "^0.1.5",
+            "semver": "^5.6.0",
+            "validate-npm-package-name": "^3.0.0"
+          },
+          "dependencies": {
+            "semver": {
+              "version": "5.7.1",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+              "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+            }
+          }
+        },
+        "npm-run-path": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+          "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+          "requires": {
+            "path-key": "^3.0.0"
+          }
+        },
+        "onetime": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.0.tgz",
+          "integrity": "sha512-5NcSkPHhwTVFIQN+TUqXoS5+dlElHXdpAWu9I0HP20YOtIi+aZ0Ct82jdlILDxjLEAWwvm+qj1m6aEtsDVmm6Q==",
+          "requires": {
+            "mimic-fn": "^2.1.0"
+          }
+        },
+        "p-finally": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-2.0.1.tgz",
+          "integrity": "sha512-vpm09aKwq6H9phqRQzecoDpD8TmVyGw70qmWlyq5onxY7tqyTTFVvxMykxQSQKILBSFlbXpypIw2T1Ml7+DDtw=="
+        },
+        "path-key": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+          "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="
+        },
+        "restore-cursor": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
+          "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
+          "requires": {
+            "onetime": "^5.1.0",
+            "signal-exit": "^3.0.2"
+          }
         },
         "to-regex-range": {
           "version": "5.0.1",
@@ -7556,6 +7893,67 @@
           "dev": true,
           "requires": {
             "is-descriptor": "^0.1.0"
+          }
+        },
+        "shebang-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+          "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="
+        },
+        "string-width": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
+          "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+          "requires": {
+            "strip-ansi": "^6.0.0"
+          },
+          "dependencies": {
+            "strip-ansi": {
+              "version": "6.0.0",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+              "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w=="
+            }
+          }
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          },
+          "dependencies": {
+            "ansi-regex": {
+              "version": "4.1.0",
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+              "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
+            }
+          }
+        },
+        "tmp": {
+          "version": "0.1.0",
+          "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.1.0.tgz",
+          "integrity": "sha512-J7Z2K08jbGcdA1kkQpJSqLF6T0tdQqpR2pnSUXsIchbPdTI9v3e85cLW0d6WDhwuAleOV71j2xWs8qMPfK7nKw==",
+          "requires": {
+            "rimraf": "^2.6.3"
+          },
+          "dependencies": {
+            "rimraf": {
+              "version": "2.7.1",
+              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+              "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+              "requires": {
+                "glob": "^7.1.3"
+              }
+            }
+          }
+        },
+        "which": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+          "requires": {
+            "isexe": "^2.0.0"
           }
         }
       }
@@ -7628,9 +8026,27 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
       "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
-      "dev": true,
       "requires": {
         "restore-cursor": "^3.1.0"
+      },
+      "dependencies": {
+        "onetime": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+          "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+          "requires": {
+            "mimic-fn": "^2.1.0"
+          }
+        },
+        "restore-cursor": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
+          "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
+          "requires": {
+            "onetime": "^5.1.0",
+            "signal-exit": "^3.0.2"
+          }
+        }
       }
     },
     "cli-spinners": {
@@ -7669,10 +8085,9 @@
       }
     },
     "cli-width": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
-      "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
-      "dev": true
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.1.tgz",
+      "integrity": "sha512-GRMWDxpOB6Dgk2E5Uo+3eEBvtOOlimMmpbFiKuLFnQzYDavtLFY3K5ona41jgN/WdRZtG7utuVSVTL4HbZHGkw=="
     },
     "cliui": {
       "version": "6.0.0",
@@ -7809,7 +8224,8 @@
     "common-tags": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.8.0.tgz",
-      "integrity": "sha512-6P6g0uetGpW/sdyUy/iQQCbFF0kWVMSIVSyYz7Zgjcgh8mgw8PQzDNZeyZ5DQ2gM7LBoZPHmnjz8rUthkBG5tw=="
+      "integrity": "sha512-6P6g0uetGpW/sdyUy/iQQCbFF0kWVMSIVSyYz7Zgjcgh8mgw8PQzDNZeyZ5DQ2gM7LBoZPHmnjz8rUthkBG5tw==",
+      "dev": true
     },
     "commondir": {
       "version": "1.0.1",
@@ -7834,6 +8250,14 @@
           "dev": true,
           "requires": {
             "is-obj": "^1.0.0"
+          }
+        },
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "requires": {
+            "is-extendable": "^0.1.0"
           }
         }
       }
@@ -7962,6 +8386,12 @@
         "xdg-basedir": "^4.0.0"
       },
       "dependencies": {
+        "crypto-random-string": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-2.0.0.tgz",
+          "integrity": "sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==",
+          "dev": true
+        },
         "make-dir": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
@@ -7976,6 +8406,15 @@
           "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
           "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
           "dev": true
+        },
+        "unique-string": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-2.0.0.tgz",
+          "integrity": "sha512-uNaeirEPvpZWSgzwsPGtU2zVSTrn/8L5q/IexZmH0eH6SA73CmAA5U4GwORTxQAZs95TAXLNqeLoPPNO5gZfWg==",
+          "dev": true,
+          "requires": {
+            "crypto-random-string": "^2.0.0"
+          }
         }
       }
     },
@@ -8045,6 +8484,12 @@
           "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
           "dev": true
         },
+        "chardet": {
+          "version": "0.7.0",
+          "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
+          "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
+          "dev": true
+        },
         "cli-cursor": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
@@ -8052,6 +8497,17 @@
           "dev": true,
           "requires": {
             "restore-cursor": "^2.0.0"
+          }
+        },
+        "external-editor": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
+          "integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
+          "dev": true,
+          "requires": {
+            "chardet": "^0.7.0",
+            "iconv-lite": "^0.4.24",
+            "tmp": "^0.0.33"
           }
         },
         "figures": {
@@ -8084,36 +8540,11 @@
             "through": "^2.3.6"
           }
         },
-        "mimic-fn": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
-          "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
-          "dev": true
-        },
         "mute-stream": {
           "version": "0.0.7",
           "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
           "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
           "dev": true
-        },
-        "onetime": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
-          "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
-          "dev": true,
-          "requires": {
-            "mimic-fn": "^1.0.0"
-          }
-        },
-        "restore-cursor": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
-          "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
-          "dev": true,
-          "requires": {
-            "onetime": "^2.0.0",
-            "signal-exit": "^3.0.2"
-          }
         },
         "strip-ansi": {
           "version": "5.2.0",
@@ -8122,6 +8553,15 @@
           "dev": true,
           "requires": {
             "ansi-regex": "^4.1.0"
+          }
+        },
+        "tmp": {
+          "version": "0.0.33",
+          "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+          "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+          "dev": true,
+          "requires": {
+            "os-tmpdir": "~1.0.2"
           }
         }
       }
@@ -8227,19 +8667,19 @@
       }
     },
     "conventional-changelog-core": {
-      "version": "4.1.7",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-core/-/conventional-changelog-core-4.1.7.tgz",
-      "integrity": "sha512-UBvSrQR2RdKbSQKh7RhueiiY4ZAIOW3+CSWdtKOwRv+KxIMNFKm1rOcGBFx0eA8AKhGkkmmacoTWJTqyz7Q0VA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-core/-/conventional-changelog-core-4.2.0.tgz",
+      "integrity": "sha512-8+xMvN6JvdDtPbGBqA7oRNyZD4od1h/SIzrWqHcKZjitbVXrFpozEeyn4iI4af1UwdrabQpiZMaV07fPUTGd4w==",
       "dev": true,
       "requires": {
         "add-stream": "^1.0.0",
-        "conventional-changelog-writer": "^4.0.16",
+        "conventional-changelog-writer": "^4.0.17",
         "conventional-commits-parser": "^3.1.0",
         "dateformat": "^3.0.0",
         "get-pkg-repo": "^1.0.0",
         "git-raw-commits": "2.0.0",
         "git-remote-origin-url": "^2.0.0",
-        "git-semver-tags": "^4.0.0",
+        "git-semver-tags": "^4.1.0",
         "lodash": "^4.17.15",
         "normalize-package-data": "^2.3.5",
         "q": "^1.5.1",
@@ -8247,6 +8687,24 @@
         "read-pkg-up": "^3.0.0",
         "shelljs": "^0.8.3",
         "through2": "^3.0.0"
+      },
+      "dependencies": {
+        "git-semver-tags": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/git-semver-tags/-/git-semver-tags-4.1.0.tgz",
+          "integrity": "sha512-TcxAGeo03HdErzKzi4fDD+xEL7gi8r2Y5YSxH6N2XYdVSV5UkBwfrt7Gqo1b+uSHCjy/sa9Y6BBBxxFLxfbhTg==",
+          "dev": true,
+          "requires": {
+            "meow": "^7.0.0",
+            "semver": "^6.0.0"
+          }
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        }
       }
     },
     "conventional-changelog-ember": {
@@ -8286,13 +8744,25 @@
       }
     },
     "conventional-changelog-jshint": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-jshint/-/conventional-changelog-jshint-2.0.7.tgz",
-      "integrity": "sha512-qHA8rmwUnLiIxANJbz650+NVzqDIwNtc0TcpIa0+uekbmKHttidvQ1dGximU3vEDdoJVKFgR3TXFqYuZmYy9ZQ==",
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-jshint/-/conventional-changelog-jshint-2.0.8.tgz",
+      "integrity": "sha512-hB/iI0IiZwnZ+seYI+qEQ4b+EMQSEC8jGIvhO2Vpz1E5p8FgLz75OX8oB1xJWl+s4xBMB6f8zJr0tC/BL7YOjw==",
       "dev": true,
       "requires": {
-        "compare-func": "^1.3.1",
+        "compare-func": "^2.0.0",
         "q": "^1.5.1"
+      },
+      "dependencies": {
+        "compare-func": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/compare-func/-/compare-func-2.0.0.tgz",
+          "integrity": "sha512-zHig5N+tPWARooBnb0Zx1MFcdfpyJrfTJ3Y5L+IFvUm8rM74hHz66z0gw0x4tijh5CorKkKUCnW82R2vmpeCRA==",
+          "dev": true,
+          "requires": {
+            "array-ify": "^1.0.0",
+            "dot-prop": "^5.1.0"
+          }
+        }
       }
     },
     "conventional-changelog-preset-loader": {
@@ -8302,12 +8772,12 @@
       "dev": true
     },
     "conventional-changelog-writer": {
-      "version": "4.0.16",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-4.0.16.tgz",
-      "integrity": "sha512-jmU1sDJDZpm/dkuFxBeRXvyNcJQeKhGtVcFFkwTphUAzyYWcwz2j36Wcv+Mv2hU3tpvLMkysOPXJTLO55AUrYQ==",
+      "version": "4.0.17",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-4.0.17.tgz",
+      "integrity": "sha512-IKQuK3bib/n032KWaSb8YlBFds+aLmzENtnKtxJy3+HqDq5kohu3g/UdNbIHeJWygfnEbZjnCKFxAW0y7ArZAw==",
       "dev": true,
       "requires": {
-        "compare-func": "^1.3.1",
+        "compare-func": "^2.0.0",
         "conventional-commits-filter": "^2.0.6",
         "dateformat": "^3.0.0",
         "handlebars": "^4.7.6",
@@ -8319,6 +8789,16 @@
         "through2": "^3.0.0"
       },
       "dependencies": {
+        "compare-func": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/compare-func/-/compare-func-2.0.0.tgz",
+          "integrity": "sha512-zHig5N+tPWARooBnb0Zx1MFcdfpyJrfTJ3Y5L+IFvUm8rM74hHz66z0gw0x4tijh5CorKkKUCnW82R2vmpeCRA==",
+          "dev": true,
+          "requires": {
+            "array-ify": "^1.0.0",
+            "dot-prop": "^5.1.0"
+          }
+        },
         "handlebars": {
           "version": "4.7.6",
           "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.6.tgz",
@@ -8462,11 +8942,11 @@
       "integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg=="
     },
     "core-js-compat": {
-      "version": "3.6.4",
-      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.6.4.tgz",
-      "integrity": "sha512-zAa3IZPvsJ0slViBQ2z+vgyyTuhd3MFn1rBQjZSKVEgB0UMYhUkCj9jJUVPgGTGqWvsBVmfnruXgTcNyTlEiSA==",
+      "version": "3.6.5",
+      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.6.5.tgz",
+      "integrity": "sha512-7ItTKOhOZbznhXAQ2g/slGg1PJV5zDO/WdkTwi7UEOJmkvsE32PWvx6mKtDjiMpjnR2CNf6BAD6sSxIlv7ptng==",
       "requires": {
-        "browserslist": "^4.8.3",
+        "browserslist": "^4.8.5",
         "semver": "7.0.0"
       },
       "dependencies": {
@@ -8601,12 +9081,6 @@
         "randomfill": "^1.0.3"
       }
     },
-    "crypto-random-string": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-2.0.0.tgz",
-      "integrity": "sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==",
-      "dev": true
-    },
     "css-select": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/css-select/-/css-select-2.1.0.tgz",
@@ -8642,9 +9116,9 @@
       "dev": true
     },
     "css-what": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/css-what/-/css-what-3.2.1.tgz",
-      "integrity": "sha512-WwOrosiQTvyms+Ti5ZC5vGEK0Vod3FTt1ca+payZqvKuGJF+dq7bG63DstxtN0dpm6FxY27a/zS3Wten+gEtGw==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-3.3.0.tgz",
+      "integrity": "sha512-pv9JPyatiPaQ6pf4OvD/dbfm0o5LviWmwxNWzblYf/1u9QZd0ihV+PMwy5jdQWQ3349kZmKEx9WXuSka2dM4cg==",
       "dev": true
     },
     "csso": {
@@ -8690,6 +9164,21 @@
       "dev": true,
       "requires": {
         "array-find-index": "^1.0.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        }
       }
     },
     "cyclist": {
@@ -8763,13 +9252,49 @@
         "map-obj": "^1.0.0"
       },
       "dependencies": {
+        "fs-tree-diff": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/fs-tree-diff/-/fs-tree-diff-2.0.1.tgz",
+          "integrity": "sha512-x+CfAZ/lJHQqwlD64pYM5QxWjzWhSjroaVsr8PW831zOApL55qPibed0c+xebaLWVr2BnHFoHdrwOv8pzt8R5A==",
+          "requires": {
+            "@types/symlink-or-copy": "^1.2.0",
+            "heimdalljs-logger": "^0.1.7",
+            "object-assign": "^4.1.0",
+            "path-posix": "^1.0.0",
+            "symlink-or-copy": "^1.1.8"
+          }
+        },
         "map-obj": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
           "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
           "dev": true
+        },
+        "rimraf": {
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        },
+        "walk-sync": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-1.1.4.tgz",
+          "integrity": "sha512-nowc9thB/Jg0KW4TgxoRjLLYRPvl3DB/98S89r4ZcJqq2B0alNcKDh6pzLkBSkPMzRSMsJghJHQi79qw0YWEkA==",
+          "requires": {
+            "@types/minimatch": "^3.0.3",
+            "ensure-posix-path": "^1.1.0",
+            "matcher-collection": "^1.1.1"
+          }
         }
       }
+    },
+    "decimal.js": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.2.0.tgz",
+      "integrity": "sha512-vDPw+rDgn3bZe1+F/pyEwb1oMG2XTlRVgAa6B4KccTEpYgF8w6eQllVbQcfIJnZyvzFtFpxnpGtx8dd7DJp/Rw==",
+      "dev": true
     },
     "decode-uri-component": {
       "version": "0.2.0",
@@ -8784,6 +9309,16 @@
       "dev": true,
       "requires": {
         "mimic-response": "^1.0.0"
+      },
+      "dependencies": {
+        "rimraf": {
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        }
       }
     },
     "deep-extend": {
@@ -8925,6 +9460,42 @@
       "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
       "requires": {
         "repeating": "^2.0.0"
+      },
+      "dependencies": {
+        "matcher-collection": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/matcher-collection/-/matcher-collection-2.0.1.tgz",
+          "integrity": "sha512-daE62nS2ZQsDg9raM0IlZzLmI2u+7ZapXBwdoeBUKAYERPDDIc0qNqA8E0Rp2D+gspKR7BgIFP52GeujaGXWeQ==",
+          "requires": {
+            "@types/minimatch": "^3.0.3",
+            "minimatch": "^3.0.2"
+          }
+        },
+        "walk-sync": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-1.1.4.tgz",
+          "integrity": "sha512-nowc9thB/Jg0KW4TgxoRjLLYRPvl3DB/98S89r4ZcJqq2B0alNcKDh6pzLkBSkPMzRSMsJghJHQi79qw0YWEkA==",
+          "requires": {
+            "@types/minimatch": "^3.0.3",
+            "ensure-posix-path": "^1.1.0",
+            "matcher-collection": "^1.1.1"
+          },
+          "dependencies": {
+            "matcher-collection": {
+              "version": "1.1.2",
+              "resolved": "https://registry.npmjs.org/matcher-collection/-/matcher-collection-1.1.2.tgz",
+              "integrity": "sha512-YQ/teqaOIIfUHedRam08PB3NK7Mjct6BvzRnJmpGDm8uFXpNr1sbY4yuflI5JcEs6COpYA0FpRQhSDBf1tT95g==",
+              "requires": {
+                "minimatch": "^3.0.2"
+              }
+            }
+          }
+        },
+        "workerpool": {
+          "version": "5.0.4",
+          "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-5.0.4.tgz",
+          "integrity": "sha512-Sywova24Ow2NQ24JPB68bI89EdqMDjUXo4OpofK/QMD7C2ZVMloYBgQ5J3PChcBJHj2vspsmGx1/3nBKXtUkXQ=="
+        }
       }
     },
     "detect-newline": {
@@ -9002,9 +9573,9 @@
           "dev": true
         },
         "entities": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/entities/-/entities-2.0.0.tgz",
-          "integrity": "sha512-D9f7V0JSRwIxlRI2mjMqufDrRDnx8p+eEOz7aUM9SuvF8gsBzra0/6tbjl1m8eQHrZlYj6PxqE00hZ1SAIKPLw==",
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-2.0.3.tgz",
+          "integrity": "sha512-MyoZ0jgnLvB2X3Lg5HqpFmn1kybDiIfEQmKzTb5apr51Rb+T3KdmMiqa70T+bhGnyv7bQ6WMj2QMHpGMmlrUYQ==",
           "dev": true
         }
       }
@@ -9194,9 +9765,9 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.3.345",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.345.tgz",
-      "integrity": "sha512-f8nx53+Z9Y+SPWGg3YdHrbYYfIJAtbUjpFfW4X1RwTZ94iUG7geg9tV8HqzAXX7XTNgyWgAFvce4yce8ZKxKmg=="
+      "version": "1.3.545",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.545.tgz",
+      "integrity": "sha512-+0R/i17u5E1cwF3g0W8Niq3UUKTUMyyT4kLkutZUHG8mDNvFsAckK3HIanzGVtixe3b6rknD8k7gHiR6nKFkgg=="
     },
     "elliptic": {
       "version": "6.5.3",
@@ -9249,6 +9820,15 @@
             "semver": "^5.3.0"
           }
         },
+        "babel-plugin-ember-modules-api-polyfill": {
+          "version": "2.13.4",
+          "resolved": "https://registry.npmjs.org/babel-plugin-ember-modules-api-polyfill/-/babel-plugin-ember-modules-api-polyfill-2.13.4.tgz",
+          "integrity": "sha512-uxQPkEQAzCYdwhZk16O9m1R4xtCRNy4oEUTBrccOPfzlIahRZJic/JeP/ZEL0BC6Mfq6r55eOg6gMF/zdFoCvA==",
+          "dev": true,
+          "requires": {
+            "ember-rfc176-data": "^0.3.13"
+          }
+        },
         "broccoli-babel-transpiler": {
           "version": "6.5.1",
           "resolved": "https://registry.npmjs.org/broccoli-babel-transpiler/-/broccoli-babel-transpiler-6.5.1.tgz",
@@ -9265,6 +9845,29 @@
             "json-stable-stringify": "^1.0.0",
             "rsvp": "^4.8.2",
             "workerpool": "^2.3.0"
+          },
+          "dependencies": {
+            "broccoli-funnel": {
+              "version": "2.0.2",
+              "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-2.0.2.tgz",
+              "integrity": "sha512-/vDTqtv7ipjEZQOVqO4vGDVAOZyuYzQ/EgGoyewfOgh1M7IQAToBKZI0oAQPgMBeFPPlIbfMuAngk+ohPBuaHQ==",
+              "dev": true,
+              "requires": {
+                "array-equal": "^1.0.0",
+                "blank-object": "^1.0.1",
+                "broccoli-plugin": "^1.3.0",
+                "debug": "^2.2.0",
+                "fast-ordered-set": "^1.0.0",
+                "fs-tree-diff": "^0.5.3",
+                "heimdalljs": "^0.2.0",
+                "minimatch": "^3.0.0",
+                "mkdirp": "^0.5.0",
+                "path-posix": "^1.0.0",
+                "rimraf": "^2.4.3",
+                "symlink-or-copy": "^1.0.0",
+                "walk-sync": "^0.3.1"
+              }
+            }
           }
         },
         "broccoli-merge-trees": {
@@ -9306,6 +9909,15 @@
             }
           }
         },
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
         "ember-cli-babel": {
           "version": "6.18.0",
           "resolved": "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-6.18.0.tgz",
@@ -9325,6 +9937,29 @@
             "clone": "^2.0.0",
             "ember-cli-version-checker": "^2.1.2",
             "semver": "^5.5.0"
+          },
+          "dependencies": {
+            "broccoli-funnel": {
+              "version": "2.0.2",
+              "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-2.0.2.tgz",
+              "integrity": "sha512-/vDTqtv7ipjEZQOVqO4vGDVAOZyuYzQ/EgGoyewfOgh1M7IQAToBKZI0oAQPgMBeFPPlIbfMuAngk+ohPBuaHQ==",
+              "dev": true,
+              "requires": {
+                "array-equal": "^1.0.0",
+                "blank-object": "^1.0.1",
+                "broccoli-plugin": "^1.3.0",
+                "debug": "^2.2.0",
+                "fast-ordered-set": "^1.0.0",
+                "fs-tree-diff": "^0.5.3",
+                "heimdalljs": "^0.2.0",
+                "minimatch": "^3.0.0",
+                "mkdirp": "^0.5.0",
+                "path-posix": "^1.0.0",
+                "rimraf": "^2.4.3",
+                "symlink-or-copy": "^1.0.0",
+                "walk-sync": "^0.3.1"
+              }
+            }
           }
         },
         "ember-cli-version-checker": {
@@ -9335,6 +9970,14 @@
           "requires": {
             "resolve": "^1.3.3",
             "semver": "^5.3.0"
+          }
+        },
+        "lru-cache": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+          "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+          "requires": {
+            "yallist": "^3.0.2"
           }
         },
         "merge-trees": {
@@ -9350,6 +9993,27 @@
             "rimraf": "^2.4.3",
             "symlink-or-copy": "^1.0.0"
           }
+        },
+        "minipass": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.1.tgz",
+          "integrity": "sha512-UFqVihv6PQgwj8/yTGvl9kPz7xIAY+R5z6XYjRInD3Gk3qx6QGSD6zEcpeG4Dy/lQnv1J6zv8ejV90hyYIKf3w==",
+          "requires": {
+            "yallist": "^4.0.0"
+          },
+          "dependencies": {
+            "yallist": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+              "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+            }
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
         },
         "rimraf": {
           "version": "2.7.1",
@@ -9407,6 +10071,1188 @@
         "webpack": "~4.28"
       },
       "dependencies": {
+        "@babel/code-frame": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
+          "integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
+          "dev": true,
+          "requires": {
+            "@babel/highlight": "^7.10.4"
+          }
+        },
+        "@babel/compat-data": {
+          "version": "7.11.0",
+          "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.11.0.tgz",
+          "integrity": "sha512-TPSvJfv73ng0pfnEOh17bYMPQbI95+nGWc71Ss4vZdRBHTDqmM9Z8ZV4rYz8Ks7sfzc95n30k6ODIq5UGnXcYQ==",
+          "dev": true,
+          "requires": {
+            "browserslist": "^4.12.0",
+            "invariant": "^2.2.4",
+            "semver": "^5.5.0"
+          }
+        },
+        "@babel/generator": {
+          "version": "7.11.4",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.11.4.tgz",
+          "integrity": "sha512-Rn26vueFx0eOoz7iifCN2UHT6rGtnkSGWSoDRIy8jZN3B91PzeSULbswfLoOWuTuAcNwpG/mxy+uCTDnZ9Mp1g==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.11.0",
+            "jsesc": "^2.5.1",
+            "source-map": "^0.5.0"
+          },
+          "dependencies": {
+            "@babel/types": {
+              "version": "7.11.0",
+              "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.11.0.tgz",
+              "integrity": "sha512-O53yME4ZZI0jO1EVGtF1ePGl0LHirG4P1ibcD80XyzZcKhcMFeCXmh4Xb1ifGBIV233Qg12x4rBfQgA+tmOukA==",
+              "dev": true,
+              "requires": {
+                "@babel/helper-validator-identifier": "^7.10.4",
+                "lodash": "^4.17.19",
+                "to-fast-properties": "^2.0.0"
+              }
+            },
+            "lodash": {
+              "version": "4.17.20",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+              "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+              "dev": true
+            }
+          }
+        },
+        "@babel/helper-annotate-as-pure": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.10.4.tgz",
+          "integrity": "sha512-XQlqKQP4vXFB7BN8fEEerrmYvHp3fK/rBkRFz9jaJbzK0B1DSfej9Kc7ZzE8Z/OnId1jpJdNAZ3BFQjWG68rcA==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.10.4"
+          },
+          "dependencies": {
+            "@babel/types": {
+              "version": "7.11.0",
+              "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.11.0.tgz",
+              "integrity": "sha512-O53yME4ZZI0jO1EVGtF1ePGl0LHirG4P1ibcD80XyzZcKhcMFeCXmh4Xb1ifGBIV233Qg12x4rBfQgA+tmOukA==",
+              "dev": true,
+              "requires": {
+                "@babel/helper-validator-identifier": "^7.10.4",
+                "lodash": "^4.17.19",
+                "to-fast-properties": "^2.0.0"
+              }
+            },
+            "lodash": {
+              "version": "4.17.20",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+              "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+              "dev": true
+            }
+          }
+        },
+        "@babel/helper-builder-binary-assignment-operator-visitor": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.10.4.tgz",
+          "integrity": "sha512-L0zGlFrGWZK4PbT8AszSfLTM5sDU1+Az/En9VrdT8/LmEiJt4zXt+Jve9DCAnQcbqDhCI+29y/L93mrDzddCcg==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-explode-assignable-expression": "^7.10.4",
+            "@babel/types": "^7.10.4"
+          },
+          "dependencies": {
+            "@babel/types": {
+              "version": "7.11.0",
+              "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.11.0.tgz",
+              "integrity": "sha512-O53yME4ZZI0jO1EVGtF1ePGl0LHirG4P1ibcD80XyzZcKhcMFeCXmh4Xb1ifGBIV233Qg12x4rBfQgA+tmOukA==",
+              "dev": true,
+              "requires": {
+                "@babel/helper-validator-identifier": "^7.10.4",
+                "lodash": "^4.17.19",
+                "to-fast-properties": "^2.0.0"
+              }
+            },
+            "lodash": {
+              "version": "4.17.20",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+              "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+              "dev": true
+            }
+          }
+        },
+        "@babel/helper-compilation-targets": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.10.4.tgz",
+          "integrity": "sha512-a3rYhlsGV0UHNDvrtOXBg8/OpfV0OKTkxKPzIplS1zpx7CygDcWWxckxZeDd3gzPzC4kUT0A4nVFDK0wGMh4MQ==",
+          "dev": true,
+          "requires": {
+            "@babel/compat-data": "^7.10.4",
+            "browserslist": "^4.12.0",
+            "invariant": "^2.2.4",
+            "levenary": "^1.1.1",
+            "semver": "^5.5.0"
+          }
+        },
+        "@babel/helper-create-class-features-plugin": {
+          "version": "7.10.5",
+          "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.10.5.tgz",
+          "integrity": "sha512-0nkdeijB7VlZoLT3r/mY3bUkw3T8WG/hNw+FATs/6+pG2039IJWjTYL0VTISqsNHMUTEnwbVnc89WIJX9Qed0A==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-function-name": "^7.10.4",
+            "@babel/helper-member-expression-to-functions": "^7.10.5",
+            "@babel/helper-optimise-call-expression": "^7.10.4",
+            "@babel/helper-plugin-utils": "^7.10.4",
+            "@babel/helper-replace-supers": "^7.10.4",
+            "@babel/helper-split-export-declaration": "^7.10.4"
+          }
+        },
+        "@babel/helper-create-regexp-features-plugin": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.10.4.tgz",
+          "integrity": "sha512-2/hu58IEPKeoLF45DBwx3XFqsbCXmkdAay4spVr2x0jYgRxrSNp+ePwvSsy9g6YSaNDcKIQVPXk1Ov8S2edk2g==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-annotate-as-pure": "^7.10.4",
+            "@babel/helper-regex": "^7.10.4",
+            "regexpu-core": "^4.7.0"
+          }
+        },
+        "@babel/helper-define-map": {
+          "version": "7.10.5",
+          "resolved": "https://registry.npmjs.org/@babel/helper-define-map/-/helper-define-map-7.10.5.tgz",
+          "integrity": "sha512-fMw4kgFB720aQFXSVaXr79pjjcW5puTCM16+rECJ/plGS+zByelE8l9nCpV1GibxTnFVmUuYG9U8wYfQHdzOEQ==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-function-name": "^7.10.4",
+            "@babel/types": "^7.10.5",
+            "lodash": "^4.17.19"
+          },
+          "dependencies": {
+            "@babel/types": {
+              "version": "7.11.0",
+              "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.11.0.tgz",
+              "integrity": "sha512-O53yME4ZZI0jO1EVGtF1ePGl0LHirG4P1ibcD80XyzZcKhcMFeCXmh4Xb1ifGBIV233Qg12x4rBfQgA+tmOukA==",
+              "dev": true,
+              "requires": {
+                "@babel/helper-validator-identifier": "^7.10.4",
+                "lodash": "^4.17.19",
+                "to-fast-properties": "^2.0.0"
+              }
+            },
+            "lodash": {
+              "version": "4.17.20",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+              "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+              "dev": true
+            }
+          }
+        },
+        "@babel/helper-explode-assignable-expression": {
+          "version": "7.11.4",
+          "resolved": "https://registry.npmjs.org/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.11.4.tgz",
+          "integrity": "sha512-ux9hm3zR4WV1Y3xXxXkdG/0gxF9nvI0YVmKVhvK9AfMoaQkemL3sJpXw+Xbz65azo8qJiEz2XVDUpK3KYhH3ZQ==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.10.4"
+          },
+          "dependencies": {
+            "@babel/types": {
+              "version": "7.11.0",
+              "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.11.0.tgz",
+              "integrity": "sha512-O53yME4ZZI0jO1EVGtF1ePGl0LHirG4P1ibcD80XyzZcKhcMFeCXmh4Xb1ifGBIV233Qg12x4rBfQgA+tmOukA==",
+              "dev": true,
+              "requires": {
+                "@babel/helper-validator-identifier": "^7.10.4",
+                "lodash": "^4.17.19",
+                "to-fast-properties": "^2.0.0"
+              }
+            },
+            "lodash": {
+              "version": "4.17.20",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+              "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+              "dev": true
+            }
+          }
+        },
+        "@babel/helper-function-name": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.10.4.tgz",
+          "integrity": "sha512-YdaSyz1n8gY44EmN7x44zBn9zQ1Ry2Y+3GTA+3vH6Mizke1Vw0aWDM66FOYEPw8//qKkmqOckrGgTYa+6sceqQ==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-get-function-arity": "^7.10.4",
+            "@babel/template": "^7.10.4",
+            "@babel/types": "^7.10.4"
+          },
+          "dependencies": {
+            "@babel/types": {
+              "version": "7.11.0",
+              "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.11.0.tgz",
+              "integrity": "sha512-O53yME4ZZI0jO1EVGtF1ePGl0LHirG4P1ibcD80XyzZcKhcMFeCXmh4Xb1ifGBIV233Qg12x4rBfQgA+tmOukA==",
+              "dev": true,
+              "requires": {
+                "@babel/helper-validator-identifier": "^7.10.4",
+                "lodash": "^4.17.19",
+                "to-fast-properties": "^2.0.0"
+              }
+            },
+            "lodash": {
+              "version": "4.17.20",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+              "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+              "dev": true
+            }
+          }
+        },
+        "@babel/helper-get-function-arity": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.10.4.tgz",
+          "integrity": "sha512-EkN3YDB+SRDgiIUnNgcmiD361ti+AVbL3f3Henf6dqqUyr5dMsorno0lJWJuLhDhkI5sYEpgj6y9kB8AOU1I2A==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.10.4"
+          },
+          "dependencies": {
+            "@babel/types": {
+              "version": "7.11.0",
+              "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.11.0.tgz",
+              "integrity": "sha512-O53yME4ZZI0jO1EVGtF1ePGl0LHirG4P1ibcD80XyzZcKhcMFeCXmh4Xb1ifGBIV233Qg12x4rBfQgA+tmOukA==",
+              "dev": true,
+              "requires": {
+                "@babel/helper-validator-identifier": "^7.10.4",
+                "lodash": "^4.17.19",
+                "to-fast-properties": "^2.0.0"
+              }
+            },
+            "lodash": {
+              "version": "4.17.20",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+              "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+              "dev": true
+            }
+          }
+        },
+        "@babel/helper-hoist-variables": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.10.4.tgz",
+          "integrity": "sha512-wljroF5PgCk2juF69kanHVs6vrLwIPNp6DLD+Lrl3hoQ3PpPPikaDRNFA+0t81NOoMt2DL6WW/mdU8k4k6ZzuA==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.10.4"
+          },
+          "dependencies": {
+            "@babel/types": {
+              "version": "7.11.0",
+              "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.11.0.tgz",
+              "integrity": "sha512-O53yME4ZZI0jO1EVGtF1ePGl0LHirG4P1ibcD80XyzZcKhcMFeCXmh4Xb1ifGBIV233Qg12x4rBfQgA+tmOukA==",
+              "dev": true,
+              "requires": {
+                "@babel/helper-validator-identifier": "^7.10.4",
+                "lodash": "^4.17.19",
+                "to-fast-properties": "^2.0.0"
+              }
+            },
+            "lodash": {
+              "version": "4.17.20",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+              "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+              "dev": true
+            }
+          }
+        },
+        "@babel/helper-member-expression-to-functions": {
+          "version": "7.11.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.11.0.tgz",
+          "integrity": "sha512-JbFlKHFntRV5qKw3YC0CvQnDZ4XMwgzzBbld7Ly4Mj4cbFy3KywcR8NtNctRToMWJOVvLINJv525Gd6wwVEx/Q==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.11.0"
+          },
+          "dependencies": {
+            "@babel/types": {
+              "version": "7.11.0",
+              "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.11.0.tgz",
+              "integrity": "sha512-O53yME4ZZI0jO1EVGtF1ePGl0LHirG4P1ibcD80XyzZcKhcMFeCXmh4Xb1ifGBIV233Qg12x4rBfQgA+tmOukA==",
+              "dev": true,
+              "requires": {
+                "@babel/helper-validator-identifier": "^7.10.4",
+                "lodash": "^4.17.19",
+                "to-fast-properties": "^2.0.0"
+              }
+            },
+            "lodash": {
+              "version": "4.17.20",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+              "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+              "dev": true
+            }
+          }
+        },
+        "@babel/helper-module-imports": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.10.4.tgz",
+          "integrity": "sha512-nEQJHqYavI217oD9+s5MUBzk6x1IlvoS9WTPfgG43CbMEeStE0v+r+TucWdx8KFGowPGvyOkDT9+7DHedIDnVw==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.10.4"
+          },
+          "dependencies": {
+            "@babel/types": {
+              "version": "7.11.0",
+              "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.11.0.tgz",
+              "integrity": "sha512-O53yME4ZZI0jO1EVGtF1ePGl0LHirG4P1ibcD80XyzZcKhcMFeCXmh4Xb1ifGBIV233Qg12x4rBfQgA+tmOukA==",
+              "dev": true,
+              "requires": {
+                "@babel/helper-validator-identifier": "^7.10.4",
+                "lodash": "^4.17.19",
+                "to-fast-properties": "^2.0.0"
+              }
+            },
+            "lodash": {
+              "version": "4.17.20",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+              "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+              "dev": true
+            }
+          }
+        },
+        "@babel/helper-module-transforms": {
+          "version": "7.11.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.11.0.tgz",
+          "integrity": "sha512-02EVu8COMuTRO1TAzdMtpBPbe6aQ1w/8fePD2YgQmxZU4gpNWaL9gK3Jp7dxlkUlUCJOTaSeA+Hrm1BRQwqIhg==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-module-imports": "^7.10.4",
+            "@babel/helper-replace-supers": "^7.10.4",
+            "@babel/helper-simple-access": "^7.10.4",
+            "@babel/helper-split-export-declaration": "^7.11.0",
+            "@babel/template": "^7.10.4",
+            "@babel/types": "^7.11.0",
+            "lodash": "^4.17.19"
+          },
+          "dependencies": {
+            "@babel/types": {
+              "version": "7.11.0",
+              "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.11.0.tgz",
+              "integrity": "sha512-O53yME4ZZI0jO1EVGtF1ePGl0LHirG4P1ibcD80XyzZcKhcMFeCXmh4Xb1ifGBIV233Qg12x4rBfQgA+tmOukA==",
+              "dev": true,
+              "requires": {
+                "@babel/helper-validator-identifier": "^7.10.4",
+                "lodash": "^4.17.19",
+                "to-fast-properties": "^2.0.0"
+              }
+            },
+            "lodash": {
+              "version": "4.17.20",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+              "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+              "dev": true
+            }
+          }
+        },
+        "@babel/helper-optimise-call-expression": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.10.4.tgz",
+          "integrity": "sha512-n3UGKY4VXwXThEiKrgRAoVPBMqeoPgHVqiHZOanAJCG9nQUL2pLRQirUzl0ioKclHGpGqRgIOkgcIJaIWLpygg==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.10.4"
+          },
+          "dependencies": {
+            "@babel/types": {
+              "version": "7.11.0",
+              "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.11.0.tgz",
+              "integrity": "sha512-O53yME4ZZI0jO1EVGtF1ePGl0LHirG4P1ibcD80XyzZcKhcMFeCXmh4Xb1ifGBIV233Qg12x4rBfQgA+tmOukA==",
+              "dev": true,
+              "requires": {
+                "@babel/helper-validator-identifier": "^7.10.4",
+                "lodash": "^4.17.19",
+                "to-fast-properties": "^2.0.0"
+              }
+            },
+            "lodash": {
+              "version": "4.17.20",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+              "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+              "dev": true
+            }
+          }
+        },
+        "@babel/helper-plugin-utils": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.4.tgz",
+          "integrity": "sha512-O4KCvQA6lLiMU9l2eawBPMf1xPP8xPfB3iEQw150hOVTqj/rfXz0ThTb4HEzqQfs2Bmo5Ay8BzxfzVtBrr9dVg==",
+          "dev": true
+        },
+        "@babel/helper-regex": {
+          "version": "7.10.5",
+          "resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.10.5.tgz",
+          "integrity": "sha512-68kdUAzDrljqBrio7DYAEgCoJHxppJOERHOgOrDN7WjOzP0ZQ1LsSDRXcemzVZaLvjaJsJEESb6qt+znNuENDg==",
+          "dev": true,
+          "requires": {
+            "lodash": "^4.17.19"
+          },
+          "dependencies": {
+            "lodash": {
+              "version": "4.17.20",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+              "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+              "dev": true
+            }
+          }
+        },
+        "@babel/helper-remap-async-to-generator": {
+          "version": "7.11.4",
+          "resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.11.4.tgz",
+          "integrity": "sha512-tR5vJ/vBa9wFy3m5LLv2faapJLnDFxNWff2SAYkSE4rLUdbp7CdObYFgI7wK4T/Mj4UzpjPwzR8Pzmr5m7MHGA==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-annotate-as-pure": "^7.10.4",
+            "@babel/helper-wrap-function": "^7.10.4",
+            "@babel/template": "^7.10.4",
+            "@babel/types": "^7.10.4"
+          },
+          "dependencies": {
+            "@babel/types": {
+              "version": "7.11.0",
+              "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.11.0.tgz",
+              "integrity": "sha512-O53yME4ZZI0jO1EVGtF1ePGl0LHirG4P1ibcD80XyzZcKhcMFeCXmh4Xb1ifGBIV233Qg12x4rBfQgA+tmOukA==",
+              "dev": true,
+              "requires": {
+                "@babel/helper-validator-identifier": "^7.10.4",
+                "lodash": "^4.17.19",
+                "to-fast-properties": "^2.0.0"
+              }
+            },
+            "lodash": {
+              "version": "4.17.20",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+              "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+              "dev": true
+            }
+          }
+        },
+        "@babel/helper-replace-supers": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.10.4.tgz",
+          "integrity": "sha512-sPxZfFXocEymYTdVK1UNmFPBN+Hv5mJkLPsYWwGBxZAxaWfFu+xqp7b6qWD0yjNuNL2VKc6L5M18tOXUP7NU0A==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-member-expression-to-functions": "^7.10.4",
+            "@babel/helper-optimise-call-expression": "^7.10.4",
+            "@babel/traverse": "^7.10.4",
+            "@babel/types": "^7.10.4"
+          },
+          "dependencies": {
+            "@babel/traverse": {
+              "version": "7.11.0",
+              "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.11.0.tgz",
+              "integrity": "sha512-ZB2V+LskoWKNpMq6E5UUCrjtDUh5IOTAyIl0dTjIEoXum/iKWkoIEKIRDnUucO6f+2FzNkE0oD4RLKoPIufDtg==",
+              "dev": true,
+              "requires": {
+                "@babel/code-frame": "^7.10.4",
+                "@babel/generator": "^7.11.0",
+                "@babel/helper-function-name": "^7.10.4",
+                "@babel/helper-split-export-declaration": "^7.11.0",
+                "@babel/parser": "^7.11.0",
+                "@babel/types": "^7.11.0",
+                "debug": "^4.1.0",
+                "globals": "^11.1.0",
+                "lodash": "^4.17.19"
+              }
+            },
+            "@babel/types": {
+              "version": "7.11.0",
+              "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.11.0.tgz",
+              "integrity": "sha512-O53yME4ZZI0jO1EVGtF1ePGl0LHirG4P1ibcD80XyzZcKhcMFeCXmh4Xb1ifGBIV233Qg12x4rBfQgA+tmOukA==",
+              "dev": true,
+              "requires": {
+                "@babel/helper-validator-identifier": "^7.10.4",
+                "lodash": "^4.17.19",
+                "to-fast-properties": "^2.0.0"
+              }
+            },
+            "debug": {
+              "version": "4.1.1",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+              "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+              "dev": true,
+              "requires": {
+                "ms": "^2.1.1"
+              }
+            },
+            "lodash": {
+              "version": "4.17.20",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+              "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+              "dev": true
+            }
+          }
+        },
+        "@babel/helper-simple-access": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.10.4.tgz",
+          "integrity": "sha512-0fMy72ej/VEvF8ULmX6yb5MtHG4uH4Dbd6I/aHDb/JVg0bbivwt9Wg+h3uMvX+QSFtwr5MeItvazbrc4jtRAXw==",
+          "dev": true,
+          "requires": {
+            "@babel/template": "^7.10.4",
+            "@babel/types": "^7.10.4"
+          },
+          "dependencies": {
+            "@babel/types": {
+              "version": "7.11.0",
+              "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.11.0.tgz",
+              "integrity": "sha512-O53yME4ZZI0jO1EVGtF1ePGl0LHirG4P1ibcD80XyzZcKhcMFeCXmh4Xb1ifGBIV233Qg12x4rBfQgA+tmOukA==",
+              "dev": true,
+              "requires": {
+                "@babel/helper-validator-identifier": "^7.10.4",
+                "lodash": "^4.17.19",
+                "to-fast-properties": "^2.0.0"
+              }
+            },
+            "lodash": {
+              "version": "4.17.20",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+              "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+              "dev": true
+            }
+          }
+        },
+        "@babel/helper-split-export-declaration": {
+          "version": "7.11.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.11.0.tgz",
+          "integrity": "sha512-74Vejvp6mHkGE+m+k5vHY93FX2cAtrw1zXrZXRlG4l410Nm9PxfEiVTn1PjDPV5SnmieiueY4AFg2xqhNFuuZg==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.11.0"
+          },
+          "dependencies": {
+            "@babel/types": {
+              "version": "7.11.0",
+              "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.11.0.tgz",
+              "integrity": "sha512-O53yME4ZZI0jO1EVGtF1ePGl0LHirG4P1ibcD80XyzZcKhcMFeCXmh4Xb1ifGBIV233Qg12x4rBfQgA+tmOukA==",
+              "dev": true,
+              "requires": {
+                "@babel/helper-validator-identifier": "^7.10.4",
+                "lodash": "^4.17.19",
+                "to-fast-properties": "^2.0.0"
+              }
+            },
+            "lodash": {
+              "version": "4.17.20",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+              "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+              "dev": true
+            }
+          }
+        },
+        "@babel/helper-wrap-function": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.10.4.tgz",
+          "integrity": "sha512-6py45WvEF0MhiLrdxtRjKjufwLL1/ob2qDJgg5JgNdojBAZSAKnAjkyOCNug6n+OBl4VW76XjvgSFTdaMcW0Ug==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-function-name": "^7.10.4",
+            "@babel/template": "^7.10.4",
+            "@babel/traverse": "^7.10.4",
+            "@babel/types": "^7.10.4"
+          },
+          "dependencies": {
+            "@babel/traverse": {
+              "version": "7.11.0",
+              "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.11.0.tgz",
+              "integrity": "sha512-ZB2V+LskoWKNpMq6E5UUCrjtDUh5IOTAyIl0dTjIEoXum/iKWkoIEKIRDnUucO6f+2FzNkE0oD4RLKoPIufDtg==",
+              "dev": true,
+              "requires": {
+                "@babel/code-frame": "^7.10.4",
+                "@babel/generator": "^7.11.0",
+                "@babel/helper-function-name": "^7.10.4",
+                "@babel/helper-split-export-declaration": "^7.11.0",
+                "@babel/parser": "^7.11.0",
+                "@babel/types": "^7.11.0",
+                "debug": "^4.1.0",
+                "globals": "^11.1.0",
+                "lodash": "^4.17.19"
+              }
+            },
+            "@babel/types": {
+              "version": "7.11.0",
+              "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.11.0.tgz",
+              "integrity": "sha512-O53yME4ZZI0jO1EVGtF1ePGl0LHirG4P1ibcD80XyzZcKhcMFeCXmh4Xb1ifGBIV233Qg12x4rBfQgA+tmOukA==",
+              "dev": true,
+              "requires": {
+                "@babel/helper-validator-identifier": "^7.10.4",
+                "lodash": "^4.17.19",
+                "to-fast-properties": "^2.0.0"
+              }
+            },
+            "debug": {
+              "version": "4.1.1",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+              "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+              "dev": true,
+              "requires": {
+                "ms": "^2.1.1"
+              }
+            },
+            "lodash": {
+              "version": "4.17.20",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+              "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+              "dev": true
+            }
+          }
+        },
+        "@babel/highlight": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
+          "integrity": "sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.10.4",
+            "chalk": "^2.0.0",
+            "js-tokens": "^4.0.0"
+          }
+        },
+        "@babel/parser": {
+          "version": "7.11.4",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.11.4.tgz",
+          "integrity": "sha512-MggwidiH+E9j5Sh8pbrX5sJvMcsqS5o+7iB42M9/k0CD63MjYbdP4nhSh7uB5wnv2/RVzTZFTxzF/kIa5mrCqA==",
+          "dev": true
+        },
+        "@babel/plugin-proposal-async-generator-functions": {
+          "version": "7.10.5",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.10.5.tgz",
+          "integrity": "sha512-cNMCVezQbrRGvXJwm9fu/1sJj9bHdGAgKodZdLqOQIpfoH3raqmRPBM17+lh7CzhiKRRBrGtZL9WcjxSoGYUSg==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.10.4",
+            "@babel/helper-remap-async-to-generator": "^7.10.4",
+            "@babel/plugin-syntax-async-generators": "^7.8.0"
+          }
+        },
+        "@babel/plugin-proposal-class-properties": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.10.4.tgz",
+          "integrity": "sha512-vhwkEROxzcHGNu2mzUC0OFFNXdZ4M23ib8aRRcJSsW8BZK9pQMD7QB7csl97NBbgGZO7ZyHUyKDnxzOaP4IrCg==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-create-class-features-plugin": "^7.10.4",
+            "@babel/helper-plugin-utils": "^7.10.4"
+          }
+        },
+        "@babel/plugin-proposal-dynamic-import": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-dynamic-import/-/plugin-proposal-dynamic-import-7.10.4.tgz",
+          "integrity": "sha512-up6oID1LeidOOASNXgv/CFbgBqTuKJ0cJjz6An5tWD+NVBNlp3VNSBxv2ZdU7SYl3NxJC7agAQDApZusV6uFwQ==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.10.4",
+            "@babel/plugin-syntax-dynamic-import": "^7.8.0"
+          }
+        },
+        "@babel/plugin-proposal-json-strings": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.10.4.tgz",
+          "integrity": "sha512-fCL7QF0Jo83uy1K0P2YXrfX11tj3lkpN7l4dMv9Y9VkowkhkQDwFHFd8IiwyK5MZjE8UpbgokkgtcReH88Abaw==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.10.4",
+            "@babel/plugin-syntax-json-strings": "^7.8.0"
+          }
+        },
+        "@babel/plugin-proposal-nullish-coalescing-operator": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-nullish-coalescing-operator/-/plugin-proposal-nullish-coalescing-operator-7.10.4.tgz",
+          "integrity": "sha512-wq5n1M3ZUlHl9sqT2ok1T2/MTt6AXE0e1Lz4WzWBr95LsAZ5qDXe4KnFuauYyEyLiohvXFMdbsOTMyLZs91Zlw==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.10.4",
+            "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.0"
+          }
+        },
+        "@babel/plugin-proposal-object-rest-spread": {
+          "version": "7.11.0",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.11.0.tgz",
+          "integrity": "sha512-wzch41N4yztwoRw0ak+37wxwJM2oiIiy6huGCoqkvSTA9acYWcPfn9Y4aJqmFFJ70KTJUu29f3DQ43uJ9HXzEA==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.10.4",
+            "@babel/plugin-syntax-object-rest-spread": "^7.8.0",
+            "@babel/plugin-transform-parameters": "^7.10.4"
+          }
+        },
+        "@babel/plugin-proposal-optional-catch-binding": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.10.4.tgz",
+          "integrity": "sha512-LflT6nPh+GK2MnFiKDyLiqSqVHkQnVf7hdoAvyTnnKj9xB3docGRsdPuxp6qqqW19ifK3xgc9U5/FwrSaCNX5g==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.10.4",
+            "@babel/plugin-syntax-optional-catch-binding": "^7.8.0"
+          }
+        },
+        "@babel/plugin-proposal-optional-chaining": {
+          "version": "7.11.0",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.11.0.tgz",
+          "integrity": "sha512-v9fZIu3Y8562RRwhm1BbMRxtqZNFmFA2EG+pT2diuU8PT3H6T/KXoZ54KgYisfOFZHV6PfvAiBIZ9Rcz+/JCxA==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.10.4",
+            "@babel/helper-skip-transparent-expression-wrappers": "^7.11.0",
+            "@babel/plugin-syntax-optional-chaining": "^7.8.0"
+          }
+        },
+        "@babel/plugin-proposal-unicode-property-regex": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.10.4.tgz",
+          "integrity": "sha512-H+3fOgPnEXFL9zGYtKQe4IDOPKYlZdF1kqFDQRRb8PK4B8af1vAGK04tF5iQAAsui+mHNBQSAtd2/ndEDe9wuA==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-create-regexp-features-plugin": "^7.10.4",
+            "@babel/helper-plugin-utils": "^7.10.4"
+          }
+        },
+        "@babel/plugin-syntax-top-level-await": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.10.4.tgz",
+          "integrity": "sha512-ni1brg4lXEmWyafKr0ccFWkJG0CeMt4WV1oyeBW6EFObF4oOHclbkj5cARxAPQyAQ2UTuplJyK4nfkXIMMFvsQ==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.10.4"
+          }
+        },
+        "@babel/plugin-transform-arrow-functions": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.10.4.tgz",
+          "integrity": "sha512-9J/oD1jV0ZCBcgnoFWFq1vJd4msoKb/TCpGNFyyLt0zABdcvgK3aYikZ8HjzB14c26bc7E3Q1yugpwGy2aTPNA==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.10.4"
+          }
+        },
+        "@babel/plugin-transform-async-to-generator": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.10.4.tgz",
+          "integrity": "sha512-F6nREOan7J5UXTLsDsZG3DXmZSVofr2tGNwfdrVwkDWHfQckbQXnXSPfD7iO+c/2HGqycwyLST3DnZ16n+cBJQ==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-module-imports": "^7.10.4",
+            "@babel/helper-plugin-utils": "^7.10.4",
+            "@babel/helper-remap-async-to-generator": "^7.10.4"
+          }
+        },
+        "@babel/plugin-transform-block-scoped-functions": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.10.4.tgz",
+          "integrity": "sha512-WzXDarQXYYfjaV1szJvN3AD7rZgZzC1JtjJZ8dMHUyiK8mxPRahynp14zzNjU3VkPqPsO38CzxiWO1c9ARZ8JA==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.10.4"
+          }
+        },
+        "@babel/plugin-transform-block-scoping": {
+          "version": "7.11.1",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.11.1.tgz",
+          "integrity": "sha512-00dYeDE0EVEHuuM+26+0w/SCL0BH2Qy7LwHuI4Hi4MH5gkC8/AqMN5uWFJIsoXZrAphiMm1iXzBw6L2T+eA0ew==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.10.4"
+          }
+        },
+        "@babel/plugin-transform-classes": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.10.4.tgz",
+          "integrity": "sha512-2oZ9qLjt161dn1ZE0Ms66xBncQH4In8Sqw1YWgBUZuGVJJS5c0OFZXL6dP2MRHrkU/eKhWg8CzFJhRQl50rQxA==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-annotate-as-pure": "^7.10.4",
+            "@babel/helper-define-map": "^7.10.4",
+            "@babel/helper-function-name": "^7.10.4",
+            "@babel/helper-optimise-call-expression": "^7.10.4",
+            "@babel/helper-plugin-utils": "^7.10.4",
+            "@babel/helper-replace-supers": "^7.10.4",
+            "@babel/helper-split-export-declaration": "^7.10.4",
+            "globals": "^11.1.0"
+          }
+        },
+        "@babel/plugin-transform-computed-properties": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.10.4.tgz",
+          "integrity": "sha512-JFwVDXcP/hM/TbyzGq3l/XWGut7p46Z3QvqFMXTfk6/09m7xZHJUN9xHfsv7vqqD4YnfI5ueYdSJtXqqBLyjBw==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.10.4"
+          }
+        },
+        "@babel/plugin-transform-destructuring": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.10.4.tgz",
+          "integrity": "sha512-+WmfvyfsyF603iPa6825mq6Qrb7uLjTOsa3XOFzlYcYDHSS4QmpOWOL0NNBY5qMbvrcf3tq0Cw+v4lxswOBpgA==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.10.4"
+          }
+        },
+        "@babel/plugin-transform-dotall-regex": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.10.4.tgz",
+          "integrity": "sha512-ZEAVvUTCMlMFAbASYSVQoxIbHm2OkG2MseW6bV2JjIygOjdVv8tuxrCTzj1+Rynh7ODb8GivUy7dzEXzEhuPaA==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-create-regexp-features-plugin": "^7.10.4",
+            "@babel/helper-plugin-utils": "^7.10.4"
+          }
+        },
+        "@babel/plugin-transform-duplicate-keys": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.10.4.tgz",
+          "integrity": "sha512-GL0/fJnmgMclHiBTTWXNlYjYsA7rDrtsazHG6mglaGSTh0KsrW04qml+Bbz9FL0LcJIRwBWL5ZqlNHKTkU3xAA==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.10.4"
+          }
+        },
+        "@babel/plugin-transform-exponentiation-operator": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.10.4.tgz",
+          "integrity": "sha512-S5HgLVgkBcRdyQAHbKj+7KyuWx8C6t5oETmUuwz1pt3WTWJhsUV0WIIXuVvfXMxl/QQyHKlSCNNtaIamG8fysw==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-builder-binary-assignment-operator-visitor": "^7.10.4",
+            "@babel/helper-plugin-utils": "^7.10.4"
+          }
+        },
+        "@babel/plugin-transform-for-of": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.10.4.tgz",
+          "integrity": "sha512-ItdQfAzu9AlEqmusA/65TqJ79eRcgGmpPPFvBnGILXZH975G0LNjP1yjHvGgfuCxqrPPueXOPe+FsvxmxKiHHQ==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.10.4"
+          }
+        },
+        "@babel/plugin-transform-function-name": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.10.4.tgz",
+          "integrity": "sha512-OcDCq2y5+E0dVD5MagT5X+yTRbcvFjDI2ZVAottGH6tzqjx/LKpgkUepu3hp/u4tZBzxxpNGwLsAvGBvQ2mJzg==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-function-name": "^7.10.4",
+            "@babel/helper-plugin-utils": "^7.10.4"
+          }
+        },
+        "@babel/plugin-transform-literals": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.10.4.tgz",
+          "integrity": "sha512-Xd/dFSTEVuUWnyZiMu76/InZxLTYilOSr1UlHV+p115Z/Le2Fi1KXkJUYz0b42DfndostYlPub3m8ZTQlMaiqQ==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.10.4"
+          }
+        },
+        "@babel/plugin-transform-member-expression-literals": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.10.4.tgz",
+          "integrity": "sha512-0bFOvPyAoTBhtcJLr9VcwZqKmSjFml1iVxvPL0ReomGU53CX53HsM4h2SzckNdkQcHox1bpAqzxBI1Y09LlBSw==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.10.4"
+          }
+        },
+        "@babel/plugin-transform-modules-amd": {
+          "version": "7.10.5",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.10.5.tgz",
+          "integrity": "sha512-elm5uruNio7CTLFItVC/rIzKLfQ17+fX7EVz5W0TMgIHFo1zY0Ozzx+lgwhL4plzl8OzVn6Qasx5DeEFyoNiRw==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-module-transforms": "^7.10.5",
+            "@babel/helper-plugin-utils": "^7.10.4",
+            "babel-plugin-dynamic-import-node": "^2.3.3"
+          }
+        },
+        "@babel/plugin-transform-modules-commonjs": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.10.4.tgz",
+          "integrity": "sha512-Xj7Uq5o80HDLlW64rVfDBhao6OX89HKUmb+9vWYaLXBZOma4gA6tw4Ni1O5qVDoZWUV0fxMYA0aYzOawz0l+1w==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-module-transforms": "^7.10.4",
+            "@babel/helper-plugin-utils": "^7.10.4",
+            "@babel/helper-simple-access": "^7.10.4",
+            "babel-plugin-dynamic-import-node": "^2.3.3"
+          }
+        },
+        "@babel/plugin-transform-modules-systemjs": {
+          "version": "7.10.5",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.10.5.tgz",
+          "integrity": "sha512-f4RLO/OL14/FP1AEbcsWMzpbUz6tssRaeQg11RH1BP/XnPpRoVwgeYViMFacnkaw4k4wjRSjn3ip1Uw9TaXuMw==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-hoist-variables": "^7.10.4",
+            "@babel/helper-module-transforms": "^7.10.5",
+            "@babel/helper-plugin-utils": "^7.10.4",
+            "babel-plugin-dynamic-import-node": "^2.3.3"
+          }
+        },
+        "@babel/plugin-transform-modules-umd": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.10.4.tgz",
+          "integrity": "sha512-mohW5q3uAEt8T45YT7Qc5ws6mWgJAaL/8BfWD9Dodo1A3RKWli8wTS+WiQ/knF+tXlPirW/1/MqzzGfCExKECA==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-module-transforms": "^7.10.4",
+            "@babel/helper-plugin-utils": "^7.10.4"
+          }
+        },
+        "@babel/plugin-transform-named-capturing-groups-regex": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.10.4.tgz",
+          "integrity": "sha512-V6LuOnD31kTkxQPhKiVYzYC/Jgdq53irJC/xBSmqcNcqFGV+PER4l6rU5SH2Vl7bH9mLDHcc0+l9HUOe4RNGKA==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-create-regexp-features-plugin": "^7.10.4"
+          }
+        },
+        "@babel/plugin-transform-new-target": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.10.4.tgz",
+          "integrity": "sha512-YXwWUDAH/J6dlfwqlWsztI2Puz1NtUAubXhOPLQ5gjR/qmQ5U96DY4FQO8At33JN4XPBhrjB8I4eMmLROjjLjw==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.10.4"
+          }
+        },
+        "@babel/plugin-transform-object-super": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.10.4.tgz",
+          "integrity": "sha512-5iTw0JkdRdJvr7sY0vHqTpnruUpTea32JHmq/atIWqsnNussbRzjEDyWep8UNztt1B5IusBYg8Irb0bLbiEBCQ==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.10.4",
+            "@babel/helper-replace-supers": "^7.10.4"
+          }
+        },
+        "@babel/plugin-transform-parameters": {
+          "version": "7.10.5",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.10.5.tgz",
+          "integrity": "sha512-xPHwUj5RdFV8l1wuYiu5S9fqWGM2DrYc24TMvUiRrPVm+SM3XeqU9BcokQX/kEUe+p2RBwy+yoiR1w/Blq6ubw==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-get-function-arity": "^7.10.4",
+            "@babel/helper-plugin-utils": "^7.10.4"
+          }
+        },
+        "@babel/plugin-transform-property-literals": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.10.4.tgz",
+          "integrity": "sha512-ofsAcKiUxQ8TY4sScgsGeR2vJIsfrzqvFb9GvJ5UdXDzl+MyYCaBj/FGzXuv7qE0aJcjWMILny1epqelnFlz8g==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.10.4"
+          }
+        },
+        "@babel/plugin-transform-regenerator": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.10.4.tgz",
+          "integrity": "sha512-3thAHwtor39A7C04XucbMg17RcZ3Qppfxr22wYzZNcVIkPHfpM9J0SO8zuCV6SZa265kxBJSrfKTvDCYqBFXGw==",
+          "dev": true,
+          "requires": {
+            "regenerator-transform": "^0.14.2"
+          }
+        },
+        "@babel/plugin-transform-reserved-words": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.10.4.tgz",
+          "integrity": "sha512-hGsw1O6Rew1fkFbDImZIEqA8GoidwTAilwCyWqLBM9f+e/u/sQMQu7uX6dyokfOayRuuVfKOW4O7HvaBWM+JlQ==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.10.4"
+          }
+        },
+        "@babel/plugin-transform-shorthand-properties": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.10.4.tgz",
+          "integrity": "sha512-AC2K/t7o07KeTIxMoHneyX90v3zkm5cjHJEokrPEAGEy3UCp8sLKfnfOIGdZ194fyN4wfX/zZUWT9trJZ0qc+Q==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.10.4"
+          }
+        },
+        "@babel/plugin-transform-spread": {
+          "version": "7.11.0",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.11.0.tgz",
+          "integrity": "sha512-UwQYGOqIdQJe4aWNyS7noqAnN2VbaczPLiEtln+zPowRNlD+79w3oi2TWfYe0eZgd+gjZCbsydN7lzWysDt+gw==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.10.4",
+            "@babel/helper-skip-transparent-expression-wrappers": "^7.11.0"
+          }
+        },
+        "@babel/plugin-transform-sticky-regex": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.10.4.tgz",
+          "integrity": "sha512-Ddy3QZfIbEV0VYcVtFDCjeE4xwVTJWTmUtorAJkn6u/92Z/nWJNV+mILyqHKrUxXYKA2EoCilgoPePymKL4DvQ==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.10.4",
+            "@babel/helper-regex": "^7.10.4"
+          }
+        },
+        "@babel/plugin-transform-template-literals": {
+          "version": "7.10.5",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.10.5.tgz",
+          "integrity": "sha512-V/lnPGIb+KT12OQikDvgSuesRX14ck5FfJXt6+tXhdkJ+Vsd0lDCVtF6jcB4rNClYFzaB2jusZ+lNISDk2mMMw==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-annotate-as-pure": "^7.10.4",
+            "@babel/helper-plugin-utils": "^7.10.4"
+          }
+        },
+        "@babel/plugin-transform-typeof-symbol": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.10.4.tgz",
+          "integrity": "sha512-QqNgYwuuW0y0H+kUE/GWSR45t/ccRhe14Fs/4ZRouNNQsyd4o3PG4OtHiIrepbM2WKUBDAXKCAK/Lk4VhzTaGA==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.10.4"
+          }
+        },
+        "@babel/plugin-transform-unicode-regex": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.10.4.tgz",
+          "integrity": "sha512-wNfsc4s8N2qnIwpO/WP2ZiSyjfpTamT2C9V9FDH/Ljub9zw6P3SjkXcFmc0RQUt96k2fmIvtla2MMjgTwIAC+A==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-create-regexp-features-plugin": "^7.10.4",
+            "@babel/helper-plugin-utils": "^7.10.4"
+          }
+        },
+        "@babel/preset-env": {
+          "version": "7.11.0",
+          "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.11.0.tgz",
+          "integrity": "sha512-2u1/k7rG/gTh02dylX2kL3S0IJNF+J6bfDSp4DI2Ma8QN6Y9x9pmAax59fsCk6QUQG0yqH47yJWA+u1I1LccAg==",
+          "dev": true,
+          "requires": {
+            "@babel/compat-data": "^7.11.0",
+            "@babel/helper-compilation-targets": "^7.10.4",
+            "@babel/helper-module-imports": "^7.10.4",
+            "@babel/helper-plugin-utils": "^7.10.4",
+            "@babel/plugin-proposal-async-generator-functions": "^7.10.4",
+            "@babel/plugin-proposal-class-properties": "^7.10.4",
+            "@babel/plugin-proposal-dynamic-import": "^7.10.4",
+            "@babel/plugin-proposal-export-namespace-from": "^7.10.4",
+            "@babel/plugin-proposal-json-strings": "^7.10.4",
+            "@babel/plugin-proposal-logical-assignment-operators": "^7.11.0",
+            "@babel/plugin-proposal-nullish-coalescing-operator": "^7.10.4",
+            "@babel/plugin-proposal-numeric-separator": "^7.10.4",
+            "@babel/plugin-proposal-object-rest-spread": "^7.11.0",
+            "@babel/plugin-proposal-optional-catch-binding": "^7.10.4",
+            "@babel/plugin-proposal-optional-chaining": "^7.11.0",
+            "@babel/plugin-proposal-private-methods": "^7.10.4",
+            "@babel/plugin-proposal-unicode-property-regex": "^7.10.4",
+            "@babel/plugin-syntax-async-generators": "^7.8.0",
+            "@babel/plugin-syntax-class-properties": "^7.10.4",
+            "@babel/plugin-syntax-dynamic-import": "^7.8.0",
+            "@babel/plugin-syntax-export-namespace-from": "^7.8.3",
+            "@babel/plugin-syntax-json-strings": "^7.8.0",
+            "@babel/plugin-syntax-logical-assignment-operators": "^7.10.4",
+            "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.0",
+            "@babel/plugin-syntax-numeric-separator": "^7.10.4",
+            "@babel/plugin-syntax-object-rest-spread": "^7.8.0",
+            "@babel/plugin-syntax-optional-catch-binding": "^7.8.0",
+            "@babel/plugin-syntax-optional-chaining": "^7.8.0",
+            "@babel/plugin-syntax-top-level-await": "^7.10.4",
+            "@babel/plugin-transform-arrow-functions": "^7.10.4",
+            "@babel/plugin-transform-async-to-generator": "^7.10.4",
+            "@babel/plugin-transform-block-scoped-functions": "^7.10.4",
+            "@babel/plugin-transform-block-scoping": "^7.10.4",
+            "@babel/plugin-transform-classes": "^7.10.4",
+            "@babel/plugin-transform-computed-properties": "^7.10.4",
+            "@babel/plugin-transform-destructuring": "^7.10.4",
+            "@babel/plugin-transform-dotall-regex": "^7.10.4",
+            "@babel/plugin-transform-duplicate-keys": "^7.10.4",
+            "@babel/plugin-transform-exponentiation-operator": "^7.10.4",
+            "@babel/plugin-transform-for-of": "^7.10.4",
+            "@babel/plugin-transform-function-name": "^7.10.4",
+            "@babel/plugin-transform-literals": "^7.10.4",
+            "@babel/plugin-transform-member-expression-literals": "^7.10.4",
+            "@babel/plugin-transform-modules-amd": "^7.10.4",
+            "@babel/plugin-transform-modules-commonjs": "^7.10.4",
+            "@babel/plugin-transform-modules-systemjs": "^7.10.4",
+            "@babel/plugin-transform-modules-umd": "^7.10.4",
+            "@babel/plugin-transform-named-capturing-groups-regex": "^7.10.4",
+            "@babel/plugin-transform-new-target": "^7.10.4",
+            "@babel/plugin-transform-object-super": "^7.10.4",
+            "@babel/plugin-transform-parameters": "^7.10.4",
+            "@babel/plugin-transform-property-literals": "^7.10.4",
+            "@babel/plugin-transform-regenerator": "^7.10.4",
+            "@babel/plugin-transform-reserved-words": "^7.10.4",
+            "@babel/plugin-transform-shorthand-properties": "^7.10.4",
+            "@babel/plugin-transform-spread": "^7.11.0",
+            "@babel/plugin-transform-sticky-regex": "^7.10.4",
+            "@babel/plugin-transform-template-literals": "^7.10.4",
+            "@babel/plugin-transform-typeof-symbol": "^7.10.4",
+            "@babel/plugin-transform-unicode-escapes": "^7.10.4",
+            "@babel/plugin-transform-unicode-regex": "^7.10.4",
+            "@babel/preset-modules": "^0.1.3",
+            "@babel/types": "^7.11.0",
+            "browserslist": "^4.12.0",
+            "core-js-compat": "^3.6.2",
+            "invariant": "^2.2.2",
+            "levenary": "^1.1.1",
+            "semver": "^5.5.0"
+          },
+          "dependencies": {
+            "@babel/types": {
+              "version": "7.11.0",
+              "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.11.0.tgz",
+              "integrity": "sha512-O53yME4ZZI0jO1EVGtF1ePGl0LHirG4P1ibcD80XyzZcKhcMFeCXmh4Xb1ifGBIV233Qg12x4rBfQgA+tmOukA==",
+              "dev": true,
+              "requires": {
+                "@babel/helper-validator-identifier": "^7.10.4",
+                "lodash": "^4.17.19",
+                "to-fast-properties": "^2.0.0"
+              }
+            },
+            "lodash": {
+              "version": "4.17.20",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+              "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+              "dev": true
+            }
+          }
+        },
+        "@babel/template": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.10.4.tgz",
+          "integrity": "sha512-ZCjD27cGJFUB6nmCB1Enki3r+L5kJveX9pq1SvAUKoICy6CZ9yD8xO086YXdYhvNjBdnekm4ZnaP5yC8Cs/1tA==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.10.4",
+            "@babel/parser": "^7.10.4",
+            "@babel/types": "^7.10.4"
+          },
+          "dependencies": {
+            "@babel/types": {
+              "version": "7.11.0",
+              "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.11.0.tgz",
+              "integrity": "sha512-O53yME4ZZI0jO1EVGtF1ePGl0LHirG4P1ibcD80XyzZcKhcMFeCXmh4Xb1ifGBIV233Qg12x4rBfQgA+tmOukA==",
+              "dev": true,
+              "requires": {
+                "@babel/helper-validator-identifier": "^7.10.4",
+                "lodash": "^4.17.19",
+                "to-fast-properties": "^2.0.0"
+              }
+            },
+            "lodash": {
+              "version": "4.17.20",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+              "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+              "dev": true
+            }
+          }
+        },
         "amd-name-resolver": {
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/amd-name-resolver/-/amd-name-resolver-1.2.0.tgz",
@@ -9425,6 +11271,24 @@
             "semver": "^5.3.0"
           }
         },
+        "babel-plugin-dynamic-import-node": {
+          "version": "2.3.3",
+          "resolved": "https://registry.npmjs.org/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.3.tgz",
+          "integrity": "sha512-jZVI+s9Zg3IqA/kdi0i6UDCybUI3aSBLnglhYbSSjKlV7yF1F/5LWv8MakQmvYpnbJDS6fcBL2KzHSxNCMtWSQ==",
+          "dev": true,
+          "requires": {
+            "object.assign": "^4.1.0"
+          }
+        },
+        "babel-plugin-ember-modules-api-polyfill": {
+          "version": "2.13.4",
+          "resolved": "https://registry.npmjs.org/babel-plugin-ember-modules-api-polyfill/-/babel-plugin-ember-modules-api-polyfill-2.13.4.tgz",
+          "integrity": "sha512-uxQPkEQAzCYdwhZk16O9m1R4xtCRNy4oEUTBrccOPfzlIahRZJic/JeP/ZEL0BC6Mfq6r55eOg6gMF/zdFoCvA==",
+          "dev": true,
+          "requires": {
+            "ember-rfc176-data": "^0.3.13"
+          }
+        },
         "broccoli-babel-transpiler": {
           "version": "6.5.1",
           "resolved": "https://registry.npmjs.org/broccoli-babel-transpiler/-/broccoli-babel-transpiler-6.5.1.tgz",
@@ -9441,6 +11305,56 @@
             "json-stable-stringify": "^1.0.0",
             "rsvp": "^4.8.2",
             "workerpool": "^2.3.0"
+          },
+          "dependencies": {
+            "broccoli-funnel": {
+              "version": "2.0.2",
+              "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-2.0.2.tgz",
+              "integrity": "sha512-/vDTqtv7ipjEZQOVqO4vGDVAOZyuYzQ/EgGoyewfOgh1M7IQAToBKZI0oAQPgMBeFPPlIbfMuAngk+ohPBuaHQ==",
+              "dev": true,
+              "requires": {
+                "array-equal": "^1.0.0",
+                "blank-object": "^1.0.1",
+                "broccoli-plugin": "^1.3.0",
+                "debug": "^2.2.0",
+                "fast-ordered-set": "^1.0.0",
+                "fs-tree-diff": "^0.5.3",
+                "heimdalljs": "^0.2.0",
+                "minimatch": "^3.0.0",
+                "mkdirp": "^0.5.0",
+                "path-posix": "^1.0.0",
+                "rimraf": "^2.4.3",
+                "symlink-or-copy": "^1.0.0",
+                "walk-sync": "^0.3.1"
+              }
+            },
+            "debug": {
+              "version": "2.6.9",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+              "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+              "dev": true,
+              "requires": {
+                "ms": "2.0.0"
+              }
+            },
+            "fs-tree-diff": {
+              "version": "0.5.9",
+              "resolved": "https://registry.npmjs.org/fs-tree-diff/-/fs-tree-diff-0.5.9.tgz",
+              "integrity": "sha512-872G8ax0kHh01m9n/2KDzgYwouKza0Ad9iFltBpNykvROvf2AGtoOzPJgGx125aolGPER3JuC7uZFrQ7bG1AZw==",
+              "dev": true,
+              "requires": {
+                "heimdalljs-logger": "^0.1.7",
+                "object-assign": "^4.1.0",
+                "path-posix": "^1.0.0",
+                "symlink-or-copy": "^1.1.8"
+              }
+            },
+            "ms": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+              "dev": true
+            }
           }
         },
         "broccoli-merge-trees": {
@@ -9494,6 +11408,24 @@
             }
           }
         },
+        "browserslist": {
+          "version": "4.14.0",
+          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.14.0.tgz",
+          "integrity": "sha512-pUsXKAF2lVwhmtpeA3LJrZ76jXuusrNyhduuQs7CDFf9foT4Y38aQOserd2lMe5DSSrjf3fx34oHwryuvxAUgQ==",
+          "dev": true,
+          "requires": {
+            "caniuse-lite": "^1.0.30001111",
+            "electron-to-chromium": "^1.3.523",
+            "escalade": "^3.0.2",
+            "node-releases": "^1.1.60"
+          }
+        },
+        "caniuse-lite": {
+          "version": "1.0.30001117",
+          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001117.tgz",
+          "integrity": "sha512-4tY0Fatzdx59kYjQs+bNxUwZB03ZEBgVmJ1UkFPz/Q8OLiUUbjct2EdpnXj0fvFTPej2EkbPIG0w8BWsjAyk1Q==",
+          "dev": true
+        },
         "debug": {
           "version": "3.2.6",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
@@ -9502,6 +11434,12 @@
           "requires": {
             "ms": "^2.1.1"
           }
+        },
+        "electron-to-chromium": {
+          "version": "1.3.540",
+          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.540.tgz",
+          "integrity": "sha512-IoGiZb8SMqTtkDYJtP8EtCdvv3VMtd1QoTlypO2RUBxRq/Wk0rU5IzhzhMckPaC9XxDqUvWsL0XKOBhTiYVN3w==",
+          "dev": true
         },
         "ember-cli-babel": {
           "version": "6.18.0",
@@ -9522,6 +11460,56 @@
             "clone": "^2.0.0",
             "ember-cli-version-checker": "^2.1.2",
             "semver": "^5.5.0"
+          },
+          "dependencies": {
+            "broccoli-funnel": {
+              "version": "2.0.2",
+              "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-2.0.2.tgz",
+              "integrity": "sha512-/vDTqtv7ipjEZQOVqO4vGDVAOZyuYzQ/EgGoyewfOgh1M7IQAToBKZI0oAQPgMBeFPPlIbfMuAngk+ohPBuaHQ==",
+              "dev": true,
+              "requires": {
+                "array-equal": "^1.0.0",
+                "blank-object": "^1.0.1",
+                "broccoli-plugin": "^1.3.0",
+                "debug": "^2.2.0",
+                "fast-ordered-set": "^1.0.0",
+                "fs-tree-diff": "^0.5.3",
+                "heimdalljs": "^0.2.0",
+                "minimatch": "^3.0.0",
+                "mkdirp": "^0.5.0",
+                "path-posix": "^1.0.0",
+                "rimraf": "^2.4.3",
+                "symlink-or-copy": "^1.0.0",
+                "walk-sync": "^0.3.1"
+              }
+            },
+            "debug": {
+              "version": "2.6.9",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+              "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+              "dev": true,
+              "requires": {
+                "ms": "2.0.0"
+              }
+            },
+            "fs-tree-diff": {
+              "version": "0.5.9",
+              "resolved": "https://registry.npmjs.org/fs-tree-diff/-/fs-tree-diff-0.5.9.tgz",
+              "integrity": "sha512-872G8ax0kHh01m9n/2KDzgYwouKza0Ad9iFltBpNykvROvf2AGtoOzPJgGx125aolGPER3JuC7uZFrQ7bG1AZw==",
+              "dev": true,
+              "requires": {
+                "heimdalljs-logger": "^0.1.7",
+                "object-assign": "^4.1.0",
+                "path-posix": "^1.0.0",
+                "symlink-or-copy": "^1.1.8"
+              }
+            },
+            "ms": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+              "dev": true
+            }
           }
         },
         "ember-cli-version-checker": {
@@ -9585,6 +11573,61 @@
             }
           }
         },
+        "node-releases": {
+          "version": "1.1.60",
+          "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.60.tgz",
+          "integrity": "sha512-gsO4vjEdQaTusZAEebUWp2a5d7dF5DYoIpDG7WySnk7BuZDW+GPpHXoXXuYawRBr/9t5q54tirPz79kFIWg4dA==",
+          "dev": true
+        },
+        "regenerate-unicode-properties": {
+          "version": "8.2.0",
+          "resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-8.2.0.tgz",
+          "integrity": "sha512-F9DjY1vKLo/tPePDycuH3dn9H1OTPIkVD9Kz4LODu+F2C75mgjAJ7x/gwy6ZcSNRAAkhNlJSOHRe8k3p+K9WhA==",
+          "dev": true,
+          "requires": {
+            "regenerate": "^1.4.0"
+          }
+        },
+        "regenerator-transform": {
+          "version": "0.14.5",
+          "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.14.5.tgz",
+          "integrity": "sha512-eOf6vka5IO151Jfsw2NO9WpGX58W6wWmefK3I1zEGr0lOD0u8rwPaNqQL1aRxUaxLeKO3ArNh3VYg1KbaD+FFw==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.8.4"
+          }
+        },
+        "regexpu-core": {
+          "version": "4.7.0",
+          "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.7.0.tgz",
+          "integrity": "sha512-TQ4KXRnIn6tz6tjnrXEkD/sshygKH/j5KzK86X8MkeHyZ8qst/LZ89j3X4/8HEIfHANTFIP/AbXakeRhWIl5YQ==",
+          "dev": true,
+          "requires": {
+            "regenerate": "^1.4.0",
+            "regenerate-unicode-properties": "^8.2.0",
+            "regjsgen": "^0.5.1",
+            "regjsparser": "^0.6.4",
+            "unicode-match-property-ecmascript": "^1.0.4",
+            "unicode-match-property-value-ecmascript": "^1.2.0"
+          }
+        },
+        "regjsparser": {
+          "version": "0.6.4",
+          "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.6.4.tgz",
+          "integrity": "sha512-64O87/dPDgfk8/RQqC4gkZoGyyWFIEUTTh80CU6CWuK5vkCGyekIx+oKcEIYtP/RAxSQltCZHCNu/mdd7fqlJw==",
+          "dev": true,
+          "requires": {
+            "jsesc": "~0.5.0"
+          },
+          "dependencies": {
+            "jsesc": {
+              "version": "0.5.0",
+              "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+              "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
+              "dev": true
+            }
+          }
+        },
         "rimraf": {
           "version": "2.7.1",
           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
@@ -9593,6 +11636,12 @@
           "requires": {
             "glob": "^7.1.3"
           }
+        },
+        "unicode-match-property-value-ecmascript": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-1.2.0.tgz",
+          "integrity": "sha512-wjuQHGQVofmSJv1uVISKLE5zO2rNGzM/KCYZch/QQvez7C1hUhBIuZ701fYXExuufJFMPhv2SyL8CyoIfMLbIQ==",
+          "dev": true
         },
         "workerpool": {
           "version": "2.3.3",
@@ -9636,6 +11685,15 @@
             "semver": "^5.3.0"
           }
         },
+        "babel-plugin-ember-modules-api-polyfill": {
+          "version": "2.13.4",
+          "resolved": "https://registry.npmjs.org/babel-plugin-ember-modules-api-polyfill/-/babel-plugin-ember-modules-api-polyfill-2.13.4.tgz",
+          "integrity": "sha512-uxQPkEQAzCYdwhZk16O9m1R4xtCRNy4oEUTBrccOPfzlIahRZJic/JeP/ZEL0BC6Mfq6r55eOg6gMF/zdFoCvA==",
+          "dev": true,
+          "requires": {
+            "ember-rfc176-data": "^0.3.13"
+          }
+        },
         "broccoli-babel-transpiler": {
           "version": "6.5.1",
           "resolved": "https://registry.npmjs.org/broccoli-babel-transpiler/-/broccoli-babel-transpiler-6.5.1.tgz",
@@ -9652,6 +11710,29 @@
             "json-stable-stringify": "^1.0.0",
             "rsvp": "^4.8.2",
             "workerpool": "^2.3.0"
+          },
+          "dependencies": {
+            "broccoli-funnel": {
+              "version": "2.0.2",
+              "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-2.0.2.tgz",
+              "integrity": "sha512-/vDTqtv7ipjEZQOVqO4vGDVAOZyuYzQ/EgGoyewfOgh1M7IQAToBKZI0oAQPgMBeFPPlIbfMuAngk+ohPBuaHQ==",
+              "dev": true,
+              "requires": {
+                "array-equal": "^1.0.0",
+                "blank-object": "^1.0.1",
+                "broccoli-plugin": "^1.3.0",
+                "debug": "^2.2.0",
+                "fast-ordered-set": "^1.0.0",
+                "fs-tree-diff": "^0.5.3",
+                "heimdalljs": "^0.2.0",
+                "minimatch": "^3.0.0",
+                "mkdirp": "^0.5.0",
+                "path-posix": "^1.0.0",
+                "rimraf": "^2.4.3",
+                "symlink-or-copy": "^1.0.0",
+                "walk-sync": "^0.3.1"
+              }
+            }
           }
         },
         "broccoli-merge-trees": {
@@ -9693,6 +11774,15 @@
             }
           }
         },
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
         "ember-cli-babel": {
           "version": "6.18.0",
           "resolved": "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-6.18.0.tgz",
@@ -9712,6 +11802,29 @@
             "clone": "^2.0.0",
             "ember-cli-version-checker": "^2.1.2",
             "semver": "^5.5.0"
+          },
+          "dependencies": {
+            "broccoli-funnel": {
+              "version": "2.0.2",
+              "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-2.0.2.tgz",
+              "integrity": "sha512-/vDTqtv7ipjEZQOVqO4vGDVAOZyuYzQ/EgGoyewfOgh1M7IQAToBKZI0oAQPgMBeFPPlIbfMuAngk+ohPBuaHQ==",
+              "dev": true,
+              "requires": {
+                "array-equal": "^1.0.0",
+                "blank-object": "^1.0.1",
+                "broccoli-plugin": "^1.3.0",
+                "debug": "^2.2.0",
+                "fast-ordered-set": "^1.0.0",
+                "fs-tree-diff": "^0.5.3",
+                "heimdalljs": "^0.2.0",
+                "minimatch": "^3.0.0",
+                "mkdirp": "^0.5.0",
+                "path-posix": "^1.0.0",
+                "rimraf": "^2.4.3",
+                "symlink-or-copy": "^1.0.0",
+                "walk-sync": "^0.3.1"
+              }
+            }
           }
         },
         "ember-cli-version-checker": {
@@ -9737,6 +11850,12 @@
             "rimraf": "^2.4.3",
             "symlink-or-copy": "^1.0.0"
           }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
         },
         "rimraf": {
           "version": "2.7.1",
@@ -9936,12 +12055,6 @@
             "@babel/types": "^7.11.0"
           }
         },
-        "@babel/helper-validator-identifier": {
-          "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
-          "integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw==",
-          "dev": true
-        },
         "@babel/helpers": {
           "version": "7.10.4",
           "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.10.4.tgz",
@@ -9982,16 +12095,6 @@
           "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.11.4.tgz",
           "integrity": "sha512-MggwidiH+E9j5Sh8pbrX5sJvMcsqS5o+7iB42M9/k0CD63MjYbdP4nhSh7uB5wnv2/RVzTZFTxzF/kIa5mrCqA==",
           "dev": true
-        },
-        "@babel/polyfill": {
-          "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/polyfill/-/polyfill-7.10.4.tgz",
-          "integrity": "sha512-8BYcnVqQ5kMD2HXoHInBH7H1b/uP3KdnwCYXOqFnXqguOyuu443WXusbIUbWEfY3Z0Txk0M1uG/8YuAMhNl6zg==",
-          "dev": true,
-          "requires": {
-            "core-js": "^2.6.5",
-            "regenerator-runtime": "^0.13.4"
-          }
         },
         "@babel/template": {
           "version": "7.10.4",
@@ -10054,24 +12157,67 @@
             "resolve": "^1.13.1"
           }
         },
-        "broccoli-babel-transpiler": {
-          "version": "7.7.0",
-          "resolved": "https://registry.npmjs.org/broccoli-babel-transpiler/-/broccoli-babel-transpiler-7.7.0.tgz",
-          "integrity": "sha512-U8Cmnv0/AcQKehiIVi6UDzqq3jqhAEbY9CvOW5vdeNRmYhFpK6bXPmVczS/nUz5g4KsPc/FdnC3zbU6yVf4e7w==",
+        "broccoli-funnel": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-2.0.2.tgz",
+          "integrity": "sha512-/vDTqtv7ipjEZQOVqO4vGDVAOZyuYzQ/EgGoyewfOgh1M7IQAToBKZI0oAQPgMBeFPPlIbfMuAngk+ohPBuaHQ==",
           "dev": true,
           "requires": {
-            "@babel/core": "^7.11.0",
-            "@babel/polyfill": "^7.10.4",
-            "broccoli-funnel": "^2.0.2",
-            "broccoli-merge-trees": "^3.0.2",
-            "broccoli-persistent-filter": "^2.2.1",
-            "clone": "^2.1.2",
-            "hash-for-dep": "^1.4.7",
-            "heimdalljs": "^0.2.1",
-            "heimdalljs-logger": "^0.1.9",
-            "json-stable-stringify": "^1.0.1",
-            "rsvp": "^4.8.4",
-            "workerpool": "^3.1.1"
+            "array-equal": "^1.0.0",
+            "blank-object": "^1.0.1",
+            "broccoli-plugin": "^1.3.0",
+            "debug": "^2.2.0",
+            "fast-ordered-set": "^1.0.0",
+            "fs-tree-diff": "^0.5.3",
+            "heimdalljs": "^0.2.0",
+            "minimatch": "^3.0.0",
+            "mkdirp": "^0.5.0",
+            "path-posix": "^1.0.0",
+            "rimraf": "^2.4.3",
+            "symlink-or-copy": "^1.0.0",
+            "walk-sync": "^0.3.1"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "2.6.9",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+              "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+              "dev": true,
+              "requires": {
+                "ms": "2.0.0"
+              }
+            },
+            "fs-tree-diff": {
+              "version": "0.5.9",
+              "resolved": "https://registry.npmjs.org/fs-tree-diff/-/fs-tree-diff-0.5.9.tgz",
+              "integrity": "sha512-872G8ax0kHh01m9n/2KDzgYwouKza0Ad9iFltBpNykvROvf2AGtoOzPJgGx125aolGPER3JuC7uZFrQ7bG1AZw==",
+              "dev": true,
+              "requires": {
+                "heimdalljs-logger": "^0.1.7",
+                "object-assign": "^4.1.0",
+                "path-posix": "^1.0.0",
+                "symlink-or-copy": "^1.1.8"
+              }
+            },
+            "matcher-collection": {
+              "version": "1.1.2",
+              "resolved": "https://registry.npmjs.org/matcher-collection/-/matcher-collection-1.1.2.tgz",
+              "integrity": "sha512-YQ/teqaOIIfUHedRam08PB3NK7Mjct6BvzRnJmpGDm8uFXpNr1sbY4yuflI5JcEs6COpYA0FpRQhSDBf1tT95g==",
+              "dev": true,
+              "requires": {
+                "minimatch": "^3.0.2"
+              }
+            },
+            "walk-sync": {
+              "version": "0.3.4",
+              "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-0.3.4.tgz",
+              "integrity": "sha512-ttGcuHA/OBnN2pcM6johpYlEms7XpO5/fyKIr48541xXedan4roO8cS1Q2S/zbbjGH/BarYDAMeS2Mi9HE5Tig==",
+              "dev": true,
+              "requires": {
+                "ensure-posix-path": "^1.0.0",
+                "matcher-collection": "^1.0.0"
+              }
+            }
           }
         },
         "broccoli-source": {
@@ -10308,6 +12454,12 @@
             "minimist": "^1.2.5"
           }
         },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        },
         "p-limit": {
           "version": "2.3.0",
           "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
@@ -10358,12 +12510,6 @@
           "integrity": "sha512-3npG2NGhTc8BWBolLLf8l/92OxMGaRLbqvIh9wjCHhDXNvk4zsxaTaCpiCunW09qWPrN2zeNSNwRLVBrQQtutA==",
           "dev": true
         },
-        "regenerator-runtime": {
-          "version": "0.13.7",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
-          "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew==",
-          "dev": true
-        },
         "reselect": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/reselect/-/reselect-4.0.0.tgz",
@@ -10387,6 +12533,15 @@
           "requires": {
             "path-root": "^0.1.1",
             "resolve": "^1.13.1"
+          }
+        },
+        "rimraf": {
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
           }
         },
         "semver": {
@@ -10609,11 +12764,6 @@
             "@babel/types": "^7.11.0"
           }
         },
-        "@babel/helper-validator-identifier": {
-          "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
-          "integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw=="
-        },
         "@babel/helpers": {
           "version": "7.10.4",
           "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.10.4.tgz",
@@ -10648,24 +12798,6 @@
             "@babel/helper-plugin-utils": "^7.10.4"
           }
         },
-        "@babel/plugin-proposal-decorators": {
-          "version": "7.10.5",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-decorators/-/plugin-proposal-decorators-7.10.5.tgz",
-          "integrity": "sha512-Sc5TAQSZuLzgY0664mMDn24Vw2P8g/VhyLyGPaWiHahhgLqeZvcGeyBZOrJW0oSKIK2mvQ22a1ENXBIQLhrEiQ==",
-          "requires": {
-            "@babel/helper-create-class-features-plugin": "^7.10.5",
-            "@babel/helper-plugin-utils": "^7.10.4",
-            "@babel/plugin-syntax-decorators": "^7.10.4"
-          }
-        },
-        "@babel/plugin-syntax-decorators": {
-          "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-decorators/-/plugin-syntax-decorators-7.10.4.tgz",
-          "integrity": "sha512-2NaoC6fAk2VMdhY1eerkfHV+lVYC1u8b+jmRJISqANCJlTxYy19HGdIkkQtix2UtkcPuPu+IlDgrVseZnU03bw==",
-          "requires": {
-            "@babel/helper-plugin-utils": "^7.10.4"
-          }
-        },
         "@babel/plugin-syntax-typescript": {
           "version": "7.10.4",
           "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.10.4.tgz",
@@ -10682,15 +12814,6 @@
             "@babel/helper-create-class-features-plugin": "^7.10.5",
             "@babel/helper-plugin-utils": "^7.10.4",
             "@babel/plugin-syntax-typescript": "^7.10.4"
-          }
-        },
-        "@babel/polyfill": {
-          "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/polyfill/-/polyfill-7.10.4.tgz",
-          "integrity": "sha512-8BYcnVqQ5kMD2HXoHInBH7H1b/uP3KdnwCYXOqFnXqguOyuu443WXusbIUbWEfY3Z0Txk0M1uG/8YuAMhNl6zg==",
-          "requires": {
-            "core-js": "^2.6.5",
-            "regenerator-runtime": "^0.13.4"
           }
         },
         "@babel/template": {
@@ -10729,37 +12852,43 @@
             "to-fast-properties": "^2.0.0"
           }
         },
-        "babel-plugin-ember-modules-api-polyfill": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/babel-plugin-ember-modules-api-polyfill/-/babel-plugin-ember-modules-api-polyfill-3.1.1.tgz",
-          "integrity": "sha512-hRTnr59fJ6cIiSiSgQLM9QRiVv/RrBAYRYggCPQDj4dvYhOWZeoX6e+1jFY1qC3tJnSDuMWu3OrDciSIi1MJ0A==",
+        "broccoli-funnel": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-2.0.2.tgz",
+          "integrity": "sha512-/vDTqtv7ipjEZQOVqO4vGDVAOZyuYzQ/EgGoyewfOgh1M7IQAToBKZI0oAQPgMBeFPPlIbfMuAngk+ohPBuaHQ==",
           "requires": {
-            "ember-rfc176-data": "^0.3.15"
+            "array-equal": "^1.0.0",
+            "blank-object": "^1.0.1",
+            "broccoli-plugin": "^1.3.0",
+            "debug": "^2.2.0",
+            "fast-ordered-set": "^1.0.0",
+            "fs-tree-diff": "^0.5.3",
+            "heimdalljs": "^0.2.0",
+            "minimatch": "^3.0.0",
+            "mkdirp": "^0.5.0",
+            "path-posix": "^1.0.0",
+            "rimraf": "^2.4.3",
+            "symlink-or-copy": "^1.0.0",
+            "walk-sync": "^0.3.1"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "2.6.9",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+              "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+              "requires": {
+                "ms": "2.0.0"
+              }
+            },
+            "rimraf": {
+              "version": "2.7.1",
+              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+              "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+              "requires": {
+                "glob": "^7.1.3"
+              }
+            }
           }
-        },
-        "broccoli-babel-transpiler": {
-          "version": "7.7.0",
-          "resolved": "https://registry.npmjs.org/broccoli-babel-transpiler/-/broccoli-babel-transpiler-7.7.0.tgz",
-          "integrity": "sha512-U8Cmnv0/AcQKehiIVi6UDzqq3jqhAEbY9CvOW5vdeNRmYhFpK6bXPmVczS/nUz5g4KsPc/FdnC3zbU6yVf4e7w==",
-          "requires": {
-            "@babel/core": "^7.11.0",
-            "@babel/polyfill": "^7.10.4",
-            "broccoli-funnel": "^2.0.2",
-            "broccoli-merge-trees": "^3.0.2",
-            "broccoli-persistent-filter": "^2.2.1",
-            "clone": "^2.1.2",
-            "hash-for-dep": "^1.4.7",
-            "heimdalljs": "^0.2.1",
-            "heimdalljs-logger": "^0.1.9",
-            "json-stable-stringify": "^1.0.1",
-            "rsvp": "^4.8.4",
-            "workerpool": "^3.1.1"
-          }
-        },
-        "ember-rfc176-data": {
-          "version": "0.3.15",
-          "resolved": "https://registry.npmjs.org/ember-rfc176-data/-/ember-rfc176-data-0.3.15.tgz",
-          "integrity": "sha512-GPKa7zRDBblRy0orxTXt5yrpp/Pf5CkuRFSIR8qMFDww0CqCKjCRwdZnWYzCM4kAEfZnXRIDDefe1tBaFw7v7w=="
         },
         "json5": {
           "version": "2.1.3",
@@ -10779,10 +12908,10 @@
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
           "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
         },
-        "regenerator-runtime": {
-          "version": "0.13.7",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
-          "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         }
       }
     },
@@ -10848,6 +12977,412 @@
         "semver": "^5.3.0"
       }
     },
+    "ember-cli-fastboot": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/ember-cli-fastboot/-/ember-cli-fastboot-2.2.3.tgz",
+      "integrity": "sha512-RdKzTOXHi59VW6a9RB0muCQd15BmY95pWkQ9eLslyeLR38/Uh1EVP+kgWxzJTxODywmMJ9SWW2HPpvxxLDfCEw==",
+      "dev": true,
+      "requires": {
+        "broccoli-concat": "^3.7.1",
+        "broccoli-file-creator": "^2.1.1",
+        "broccoli-funnel": "^2.0.1",
+        "broccoli-merge-trees": "^3.0.1",
+        "broccoli-plugin": "^1.3.1",
+        "chalk": "^2.4.1",
+        "ember-cli-babel": "^7.1.0",
+        "ember-cli-lodash-subset": "2.0.1",
+        "ember-cli-preprocess-registry": "^3.1.2",
+        "ember-cli-version-checker": "^3.0.0",
+        "fastboot": "^2.0.0",
+        "fastboot-express-middleware": "^2.0.0",
+        "fastboot-transform": "^0.1.3",
+        "fs-extra": "^7.0.0",
+        "json-stable-stringify": "^1.0.1",
+        "md5-hex": "^2.0.0",
+        "silent-error": "^1.1.0"
+      },
+      "dependencies": {
+        "broccoli-concat": {
+          "version": "3.7.5",
+          "resolved": "https://registry.npmjs.org/broccoli-concat/-/broccoli-concat-3.7.5.tgz",
+          "integrity": "sha512-rDs1Mej3Ej0Cy5yIO9oIQq5+BCv0opAwS2NW7M0BeCsAMeFM42Z/zacDUC6jKc5OV5wiHvGTyCPLnZkMe0h6kQ==",
+          "dev": true,
+          "requires": {
+            "broccoli-debug": "^0.6.5",
+            "broccoli-kitchen-sink-helpers": "^0.3.1",
+            "broccoli-plugin": "^1.3.0",
+            "ensure-posix-path": "^1.0.2",
+            "fast-sourcemap-concat": "^1.4.0",
+            "find-index": "^1.1.0",
+            "fs-extra": "^4.0.3",
+            "fs-tree-diff": "^0.5.7",
+            "lodash.merge": "^4.6.2",
+            "lodash.omit": "^4.1.0",
+            "lodash.uniq": "^4.2.0",
+            "walk-sync": "^0.3.2"
+          },
+          "dependencies": {
+            "fs-extra": {
+              "version": "4.0.3",
+              "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.3.tgz",
+              "integrity": "sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==",
+              "dev": true,
+              "requires": {
+                "graceful-fs": "^4.1.2",
+                "jsonfile": "^4.0.0",
+                "universalify": "^0.1.0"
+              }
+            }
+          }
+        },
+        "broccoli-file-creator": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/broccoli-file-creator/-/broccoli-file-creator-2.1.1.tgz",
+          "integrity": "sha512-YpjOExWr92C5vhnK0kmD81kM7U09kdIRZk9w4ZDCDHuHXW+VE/x6AGEOQQW3loBQQ6Jk+k+TSm8dESy4uZsnjw==",
+          "dev": true,
+          "requires": {
+            "broccoli-plugin": "^1.1.0",
+            "mkdirp": "^0.5.1"
+          }
+        },
+        "broccoli-funnel": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-2.0.2.tgz",
+          "integrity": "sha512-/vDTqtv7ipjEZQOVqO4vGDVAOZyuYzQ/EgGoyewfOgh1M7IQAToBKZI0oAQPgMBeFPPlIbfMuAngk+ohPBuaHQ==",
+          "dev": true,
+          "requires": {
+            "array-equal": "^1.0.0",
+            "blank-object": "^1.0.1",
+            "broccoli-plugin": "^1.3.0",
+            "debug": "^2.2.0",
+            "fast-ordered-set": "^1.0.0",
+            "fs-tree-diff": "^0.5.3",
+            "heimdalljs": "^0.2.0",
+            "minimatch": "^3.0.0",
+            "mkdirp": "^0.5.0",
+            "path-posix": "^1.0.0",
+            "rimraf": "^2.4.3",
+            "symlink-or-copy": "^1.0.0",
+            "walk-sync": "^0.3.1"
+          }
+        },
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ember-cli-version-checker": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-3.1.3.tgz",
+          "integrity": "sha512-PZNSvpzwWgv68hcXxyjREpj3WWb81A7rtYNQq1lLEgrWIchF8ApKJjWP3NBpHjaatwILkZAV8klair5WFlXAKg==",
+          "dev": true,
+          "requires": {
+            "resolve-package-path": "^1.2.6",
+            "semver": "^5.6.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        },
+        "rimraf": {
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        }
+      }
+    },
+    "ember-cli-fastboot-testing": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/ember-cli-fastboot-testing/-/ember-cli-fastboot-testing-0.4.0.tgz",
+      "integrity": "sha512-WYzMgveWHTZxDAK2MN/0mHQHvA9nQQbr5m50S/AhtXQ2xH9MRiQD1KlmB5R78XcAvKexdF0oG4vSFd+yyTntjA==",
+      "dev": true,
+      "requires": {
+        "body-parser": "^1.18.3",
+        "ember-auto-import": "^1.2.15",
+        "ember-cli-babel": "^7.8.0",
+        "fastboot": "^3.0.3",
+        "json-fn": "^1.1.1",
+        "minimist": "^1.2.0",
+        "nock": "^12.0.3",
+        "resolve": "^1.10.0",
+        "whatwg-fetch": "^3.0.0"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "7.4.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.0.tgz",
+          "integrity": "sha512-+G7P8jJmCHr+S+cLfQxygbWhXy+8YTVGzAkpEbcLo2mLoL7tij/VG41QSHACSf5QgYRhMZYHuNc6drJaO0Da+w==",
+          "dev": true
+        },
+        "acorn-globals": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-6.0.0.tgz",
+          "integrity": "sha512-ZQl7LOWaF5ePqqcX4hLuv/bLXYQNfNWw2c0/yX/TsPRKamzHcTGQnlCjHT3TsmkOUVEPS3crCxiPfdzE/Trlhg==",
+          "dev": true,
+          "requires": {
+            "acorn": "^7.1.1",
+            "acorn-walk": "^7.1.1"
+          }
+        },
+        "acorn-walk": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-7.2.0.tgz",
+          "integrity": "sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "dev": true,
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "cssom": {
+          "version": "0.4.4",
+          "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.4.4.tgz",
+          "integrity": "sha512-p3pvU7r1MyyqbTk+WbNJIgJjG2VmTIaB10rI93LzVPrmDJKkzKYMtxxyAvQXR/NS6otuzveI7+7BBq3SjBS2mw==",
+          "dev": true
+        },
+        "cssstyle": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-2.3.0.tgz",
+          "integrity": "sha512-AZL67abkUzIuvcHqk7c09cezpGNcxUxU4Ioi/05xHk4DQeTkWmGYftIE6ctU6AEt+Gn4n1lDStOtj7FKycP71A==",
+          "dev": true,
+          "requires": {
+            "cssom": "~0.3.6"
+          },
+          "dependencies": {
+            "cssom": {
+              "version": "0.3.8",
+              "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
+              "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==",
+              "dev": true
+            }
+          }
+        },
+        "data-urls": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-2.0.0.tgz",
+          "integrity": "sha512-X5eWTSXO/BJmpdIKCRuKUgSCgAN0OwliVK3yPKbwIWU1Tdw5BRajxlzMidvh+gwko9AfQ9zIj52pzF91Q3YAvQ==",
+          "dev": true,
+          "requires": {
+            "abab": "^2.0.3",
+            "whatwg-mimetype": "^2.3.0",
+            "whatwg-url": "^8.0.0"
+          }
+        },
+        "domexception": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/domexception/-/domexception-2.0.1.tgz",
+          "integrity": "sha512-yxJ2mFy/sibVQlu5qHjOkf9J3K6zgmCxgJ94u2EdvDOV09H+32LtRswEcUsmUWN72pVLOEnTSRaIVVzVQgS0dg==",
+          "dev": true,
+          "requires": {
+            "webidl-conversions": "^5.0.0"
+          },
+          "dependencies": {
+            "webidl-conversions": {
+              "version": "5.0.0",
+              "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-5.0.0.tgz",
+              "integrity": "sha512-VlZwKPCkYKxQgeSbH5EyngOmRp7Ww7I9rQLERETtf5ofd9pGeswWiOtogpEO850jziPRarreGxn5QIiTqpb2wA==",
+              "dev": true
+            }
+          }
+        },
+        "escodegen": {
+          "version": "1.14.3",
+          "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.14.3.tgz",
+          "integrity": "sha512-qFcX0XJkdg+PB3xjZZG/wKSuT1PnQWx57+TVSjIMmILd2yC/6ByYElPwJnslDsuWuSAp4AwJGumarAAmJch5Kw==",
+          "dev": true,
+          "requires": {
+            "esprima": "^4.0.1",
+            "estraverse": "^4.2.0",
+            "esutils": "^2.0.2",
+            "optionator": "^0.8.1",
+            "source-map": "~0.6.1"
+          }
+        },
+        "fastboot": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/fastboot/-/fastboot-3.1.0.tgz",
+          "integrity": "sha512-1GyX0seImE0l4Di/LVwTzL1XqXKECQvvDeEZmReNwMUDbsQxETGz3j7XUq/eWSxl1o4R/vZomvxOXdtae6kpfA==",
+          "dev": true,
+          "requires": {
+            "chalk": "^3.0.0",
+            "cookie": "^0.4.0",
+            "debug": "^4.1.1",
+            "jsdom": "^16.2.2",
+            "resolve": "^1.15.0",
+            "simple-dom": "^1.4.0",
+            "source-map-support": "^0.5.16"
+          }
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "html-encoding-sniffer": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-2.0.1.tgz",
+          "integrity": "sha512-D5JbOMBIR/TVZkubHT+OyT2705QvogUW4IBn6nHd756OwieSF9aDYFj4dv6HHEVGYbHaLETa3WggZYWWMyy3ZQ==",
+          "dev": true,
+          "requires": {
+            "whatwg-encoding": "^1.0.5"
+          }
+        },
+        "jsdom": {
+          "version": "16.4.0",
+          "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-16.4.0.tgz",
+          "integrity": "sha512-lYMm3wYdgPhrl7pDcRmvzPhhrGVBeVhPIqeHjzeiHN3DFmD1RBpbExbi8vU7BJdH8VAZYovR8DMt0PNNDM7k8w==",
+          "dev": true,
+          "requires": {
+            "abab": "^2.0.3",
+            "acorn": "^7.1.1",
+            "acorn-globals": "^6.0.0",
+            "cssom": "^0.4.4",
+            "cssstyle": "^2.2.0",
+            "data-urls": "^2.0.0",
+            "decimal.js": "^10.2.0",
+            "domexception": "^2.0.1",
+            "escodegen": "^1.14.1",
+            "html-encoding-sniffer": "^2.0.1",
+            "is-potential-custom-element-name": "^1.0.0",
+            "nwsapi": "^2.2.0",
+            "parse5": "5.1.1",
+            "request": "^2.88.2",
+            "request-promise-native": "^1.0.8",
+            "saxes": "^5.0.0",
+            "symbol-tree": "^3.2.4",
+            "tough-cookie": "^3.0.1",
+            "w3c-hr-time": "^1.0.2",
+            "w3c-xmlserializer": "^2.0.0",
+            "webidl-conversions": "^6.1.0",
+            "whatwg-encoding": "^1.0.5",
+            "whatwg-mimetype": "^2.3.0",
+            "whatwg-url": "^8.0.0",
+            "ws": "^7.2.3",
+            "xml-name-validator": "^3.0.0"
+          }
+        },
+        "parse5": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/parse5/-/parse5-5.1.1.tgz",
+          "integrity": "sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug==",
+          "dev": true
+        },
+        "saxes": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/saxes/-/saxes-5.0.1.tgz",
+          "integrity": "sha512-5LBh1Tls8c9xgGjw3QrMwETmTMVk0oFgvrFSvWx62llR2hcEInrKNZ2GZCCuuy2lvWrdl5jhbpeqc5hRYKFOcw==",
+          "dev": true,
+          "requires": {
+            "xmlchars": "^2.2.0"
+          }
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        },
+        "source-map-support": {
+          "version": "0.5.19",
+          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
+          "integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
+          "dev": true,
+          "requires": {
+            "buffer-from": "^1.0.0",
+            "source-map": "^0.6.0"
+          }
+        },
+        "supports-color": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        },
+        "tough-cookie": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-3.0.1.tgz",
+          "integrity": "sha512-yQyJ0u4pZsv9D4clxO69OEjLWYw+jbgspjTue4lTQZLfV0c5l1VmK2y1JK8E9ahdpltPOaAThPcp5nKPUgSnsg==",
+          "dev": true,
+          "requires": {
+            "ip-regex": "^2.1.0",
+            "psl": "^1.1.28",
+            "punycode": "^2.1.1"
+          }
+        },
+        "tr46": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/tr46/-/tr46-2.0.2.tgz",
+          "integrity": "sha512-3n1qG+/5kg+jrbTzwAykB5yRYtQCTqOGKq5U5PE3b0a1/mzo6snDhjGS0zJVJunO0NrT3Dg1MLy5TjWP/UJppg==",
+          "dev": true,
+          "requires": {
+            "punycode": "^2.1.1"
+          }
+        },
+        "webidl-conversions": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-6.1.0.tgz",
+          "integrity": "sha512-qBIvFLGiBpLjfwmYAaHPXsn+ho5xZnGvyGvsarywGNc8VyQJUMHJ8OBKGGrPER0okBeMDaan4mNBlgBROxuI8w==",
+          "dev": true
+        },
+        "whatwg-url": {
+          "version": "8.2.1",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-8.2.1.tgz",
+          "integrity": "sha512-ZmVCr6nfBeaMxEHALLEGy0LszYjpJqf6PVNQUQ1qd9Et+q7Jpygd4rGGDXgHjD8e99yLFseD69msHDM4YwPZ4A==",
+          "dev": true,
+          "requires": {
+            "lodash.sortby": "^4.7.0",
+            "tr46": "^2.0.2",
+            "webidl-conversions": "^6.1.0"
+          }
+        }
+      }
+    },
     "ember-cli-get-component-path-option": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/ember-cli-get-component-path-option/-/ember-cli-get-component-path-option-1.0.0.tgz",
@@ -10876,1060 +13411,11 @@
         }
       }
     },
-    "ember-cli-head": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/ember-cli-head/-/ember-cli-head-1.0.0.tgz",
-      "integrity": "sha512-7gj8H/KSF+e4pxSKxj9F8hq9PUt2vOjCaOvRdxdmyoHnko4QbiUnv8ASpXuop+m15eNIUGOlaLrJJ3jM8oQEUw==",
-      "requires": {
-        "ember-cli-babel": "^7.19.0",
-        "ember-cli-htmlbars": "^4.3.1",
-        "ember-in-element-polyfill": "^1.0.0"
-      },
-      "dependencies": {
-        "@babel/code-frame": {
-          "version": "7.10.1",
-          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.1.tgz",
-          "integrity": "sha512-IGhtTmpjGbYzcEDOw7DcQtbQSXcG9ftmAXtWTu9V936vDye4xjjekktFAtgZsWpzTj/X01jocB46mTywm/4SZw==",
-          "requires": {
-            "@babel/highlight": "^7.10.1"
-          }
-        },
-        "@babel/compat-data": {
-          "version": "7.10.1",
-          "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.10.1.tgz",
-          "integrity": "sha512-CHvCj7So7iCkGKPRFUfryXIkU2gSBw7VSZFYLsqVhrS47269VK2Hfi9S/YcublPMW8k1u2bQBlbDruoQEm4fgw==",
-          "requires": {
-            "browserslist": "^4.12.0",
-            "invariant": "^2.2.4",
-            "semver": "^5.5.0"
-          }
-        },
-        "@babel/core": {
-          "version": "7.10.2",
-          "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.10.2.tgz",
-          "integrity": "sha512-KQmV9yguEjQsXqyOUGKjS4+3K8/DlOCE2pZcq4augdQmtTy5iv5EHtmMSJ7V4c1BIPjuwtZYqYLCq9Ga+hGBRQ==",
-          "requires": {
-            "@babel/code-frame": "^7.10.1",
-            "@babel/generator": "^7.10.2",
-            "@babel/helper-module-transforms": "^7.10.1",
-            "@babel/helpers": "^7.10.1",
-            "@babel/parser": "^7.10.2",
-            "@babel/template": "^7.10.1",
-            "@babel/traverse": "^7.10.1",
-            "@babel/types": "^7.10.2",
-            "convert-source-map": "^1.7.0",
-            "debug": "^4.1.0",
-            "gensync": "^1.0.0-beta.1",
-            "json5": "^2.1.2",
-            "lodash": "^4.17.13",
-            "resolve": "^1.3.2",
-            "semver": "^5.4.1",
-            "source-map": "^0.5.0"
-          }
-        },
-        "@babel/generator": {
-          "version": "7.10.2",
-          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.10.2.tgz",
-          "integrity": "sha512-AxfBNHNu99DTMvlUPlt1h2+Hn7knPpH5ayJ8OqDWSeLld+Fi2AYBTC/IejWDM9Edcii4UzZRCsbUt0WlSDsDsA==",
-          "requires": {
-            "@babel/types": "^7.10.2",
-            "jsesc": "^2.5.1",
-            "lodash": "^4.17.13",
-            "source-map": "^0.5.0"
-          }
-        },
-        "@babel/helper-annotate-as-pure": {
-          "version": "7.10.1",
-          "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.10.1.tgz",
-          "integrity": "sha512-ewp3rvJEwLaHgyWGe4wQssC2vjks3E80WiUe2BpMb0KhreTjMROCbxXcEovTrbeGVdQct5VjQfrv9EgC+xMzCw==",
-          "requires": {
-            "@babel/types": "^7.10.1"
-          }
-        },
-        "@babel/helper-builder-binary-assignment-operator-visitor": {
-          "version": "7.10.1",
-          "resolved": "https://registry.npmjs.org/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.10.1.tgz",
-          "integrity": "sha512-cQpVq48EkYxUU0xozpGCLla3wlkdRRqLWu1ksFMXA9CM5KQmyyRpSEsYXbao7JUkOw/tAaYKCaYyZq6HOFYtyw==",
-          "requires": {
-            "@babel/helper-explode-assignable-expression": "^7.10.1",
-            "@babel/types": "^7.10.1"
-          }
-        },
-        "@babel/helper-compilation-targets": {
-          "version": "7.10.2",
-          "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.10.2.tgz",
-          "integrity": "sha512-hYgOhF4To2UTB4LTaZepN/4Pl9LD4gfbJx8A34mqoluT8TLbof1mhUlYuNWTEebONa8+UlCC4X0TEXu7AOUyGA==",
-          "requires": {
-            "@babel/compat-data": "^7.10.1",
-            "browserslist": "^4.12.0",
-            "invariant": "^2.2.4",
-            "levenary": "^1.1.1",
-            "semver": "^5.5.0"
-          }
-        },
-        "@babel/helper-create-class-features-plugin": {
-          "version": "7.10.2",
-          "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.10.2.tgz",
-          "integrity": "sha512-5C/QhkGFh1vqcziq1vAL6SI9ymzUp8BCYjFpvYVhWP4DlATIb3u5q3iUd35mvlyGs8fO7hckkW7i0tmH+5+bvQ==",
-          "requires": {
-            "@babel/helper-function-name": "^7.10.1",
-            "@babel/helper-member-expression-to-functions": "^7.10.1",
-            "@babel/helper-optimise-call-expression": "^7.10.1",
-            "@babel/helper-plugin-utils": "^7.10.1",
-            "@babel/helper-replace-supers": "^7.10.1",
-            "@babel/helper-split-export-declaration": "^7.10.1"
-          }
-        },
-        "@babel/helper-create-regexp-features-plugin": {
-          "version": "7.10.1",
-          "resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.10.1.tgz",
-          "integrity": "sha512-Rx4rHS0pVuJn5pJOqaqcZR4XSgeF9G/pO/79t+4r7380tXFJdzImFnxMU19f83wjSrmKHq6myrM10pFHTGzkUA==",
-          "requires": {
-            "@babel/helper-annotate-as-pure": "^7.10.1",
-            "@babel/helper-regex": "^7.10.1",
-            "regexpu-core": "^4.7.0"
-          }
-        },
-        "@babel/helper-define-map": {
-          "version": "7.10.1",
-          "resolved": "https://registry.npmjs.org/@babel/helper-define-map/-/helper-define-map-7.10.1.tgz",
-          "integrity": "sha512-+5odWpX+OnvkD0Zmq7panrMuAGQBu6aPUgvMzuMGo4R+jUOvealEj2hiqI6WhxgKrTpFoFj0+VdsuA8KDxHBDg==",
-          "requires": {
-            "@babel/helper-function-name": "^7.10.1",
-            "@babel/types": "^7.10.1",
-            "lodash": "^4.17.13"
-          }
-        },
-        "@babel/helper-explode-assignable-expression": {
-          "version": "7.10.1",
-          "resolved": "https://registry.npmjs.org/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.10.1.tgz",
-          "integrity": "sha512-vcUJ3cDjLjvkKzt6rHrl767FeE7pMEYfPanq5L16GRtrXIoznc0HykNW2aEYkcnP76P0isoqJ34dDMFZwzEpJg==",
-          "requires": {
-            "@babel/traverse": "^7.10.1",
-            "@babel/types": "^7.10.1"
-          }
-        },
-        "@babel/helper-function-name": {
-          "version": "7.10.1",
-          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.10.1.tgz",
-          "integrity": "sha512-fcpumwhs3YyZ/ttd5Rz0xn0TpIwVkN7X0V38B9TWNfVF42KEkhkAAuPCQ3oXmtTRtiPJrmZ0TrfS0GKF0eMaRQ==",
-          "requires": {
-            "@babel/helper-get-function-arity": "^7.10.1",
-            "@babel/template": "^7.10.1",
-            "@babel/types": "^7.10.1"
-          }
-        },
-        "@babel/helper-get-function-arity": {
-          "version": "7.10.1",
-          "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.10.1.tgz",
-          "integrity": "sha512-F5qdXkYGOQUb0hpRaPoetF9AnsXknKjWMZ+wmsIRsp5ge5sFh4c3h1eH2pRTTuy9KKAA2+TTYomGXAtEL2fQEw==",
-          "requires": {
-            "@babel/types": "^7.10.1"
-          }
-        },
-        "@babel/helper-hoist-variables": {
-          "version": "7.10.1",
-          "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.10.1.tgz",
-          "integrity": "sha512-vLm5srkU8rI6X3+aQ1rQJyfjvCBLXP8cAGeuw04zeAM2ItKb1e7pmVmLyHb4sDaAYnLL13RHOZPLEtcGZ5xvjg==",
-          "requires": {
-            "@babel/types": "^7.10.1"
-          }
-        },
-        "@babel/helper-member-expression-to-functions": {
-          "version": "7.10.1",
-          "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.10.1.tgz",
-          "integrity": "sha512-u7XLXeM2n50gb6PWJ9hoO5oO7JFPaZtrh35t8RqKLT1jFKj9IWeD1zrcrYp1q1qiZTdEarfDWfTIP8nGsu0h5g==",
-          "requires": {
-            "@babel/types": "^7.10.1"
-          }
-        },
-        "@babel/helper-module-imports": {
-          "version": "7.10.1",
-          "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.10.1.tgz",
-          "integrity": "sha512-SFxgwYmZ3HZPyZwJRiVNLRHWuW2OgE5k2nrVs6D9Iv4PPnXVffuEHy83Sfx/l4SqF+5kyJXjAyUmrG7tNm+qVg==",
-          "requires": {
-            "@babel/types": "^7.10.1"
-          }
-        },
-        "@babel/helper-module-transforms": {
-          "version": "7.10.1",
-          "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.10.1.tgz",
-          "integrity": "sha512-RLHRCAzyJe7Q7sF4oy2cB+kRnU4wDZY/H2xJFGof+M+SJEGhZsb+GFj5j1AD8NiSaVBJ+Pf0/WObiXu/zxWpFg==",
-          "requires": {
-            "@babel/helper-module-imports": "^7.10.1",
-            "@babel/helper-replace-supers": "^7.10.1",
-            "@babel/helper-simple-access": "^7.10.1",
-            "@babel/helper-split-export-declaration": "^7.10.1",
-            "@babel/template": "^7.10.1",
-            "@babel/types": "^7.10.1",
-            "lodash": "^4.17.13"
-          }
-        },
-        "@babel/helper-optimise-call-expression": {
-          "version": "7.10.1",
-          "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.10.1.tgz",
-          "integrity": "sha512-a0DjNS1prnBsoKx83dP2falChcs7p3i8VMzdrSbfLhuQra/2ENC4sbri34dz/rWmDADsmF1q5GbfaXydh0Jbjg==",
-          "requires": {
-            "@babel/types": "^7.10.1"
-          }
-        },
-        "@babel/helper-plugin-utils": {
-          "version": "7.10.1",
-          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.1.tgz",
-          "integrity": "sha512-fvoGeXt0bJc7VMWZGCAEBEMo/HAjW2mP8apF5eXK0wSqwLAVHAISCWRoLMBMUs2kqeaG77jltVqu4Hn8Egl3nA=="
-        },
-        "@babel/helper-regex": {
-          "version": "7.10.1",
-          "resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.10.1.tgz",
-          "integrity": "sha512-7isHr19RsIJWWLLFn21ubFt223PjQyg1HY7CZEMRr820HttHPpVvrsIN3bUOo44DEfFV4kBXO7Abbn9KTUZV7g==",
-          "requires": {
-            "lodash": "^4.17.13"
-          }
-        },
-        "@babel/helper-remap-async-to-generator": {
-          "version": "7.10.1",
-          "resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.10.1.tgz",
-          "integrity": "sha512-RfX1P8HqsfgmJ6CwaXGKMAqbYdlleqglvVtht0HGPMSsy2V6MqLlOJVF/0Qyb/m2ZCi2z3q3+s6Pv7R/dQuZ6A==",
-          "requires": {
-            "@babel/helper-annotate-as-pure": "^7.10.1",
-            "@babel/helper-wrap-function": "^7.10.1",
-            "@babel/template": "^7.10.1",
-            "@babel/traverse": "^7.10.1",
-            "@babel/types": "^7.10.1"
-          }
-        },
-        "@babel/helper-replace-supers": {
-          "version": "7.10.1",
-          "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.10.1.tgz",
-          "integrity": "sha512-SOwJzEfpuQwInzzQJGjGaiG578UYmyi2Xw668klPWV5n07B73S0a9btjLk/52Mlcxa+5AdIYqws1KyXRfMoB7A==",
-          "requires": {
-            "@babel/helper-member-expression-to-functions": "^7.10.1",
-            "@babel/helper-optimise-call-expression": "^7.10.1",
-            "@babel/traverse": "^7.10.1",
-            "@babel/types": "^7.10.1"
-          }
-        },
-        "@babel/helper-simple-access": {
-          "version": "7.10.1",
-          "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.10.1.tgz",
-          "integrity": "sha512-VSWpWzRzn9VtgMJBIWTZ+GP107kZdQ4YplJlCmIrjoLVSi/0upixezHCDG8kpPVTBJpKfxTH01wDhh+jS2zKbw==",
-          "requires": {
-            "@babel/template": "^7.10.1",
-            "@babel/types": "^7.10.1"
-          }
-        },
-        "@babel/helper-split-export-declaration": {
-          "version": "7.10.1",
-          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.10.1.tgz",
-          "integrity": "sha512-UQ1LVBPrYdbchNhLwj6fetj46BcFwfS4NllJo/1aJsT+1dLTEnXJL0qHqtY7gPzF8S2fXBJamf1biAXV3X077g==",
-          "requires": {
-            "@babel/types": "^7.10.1"
-          }
-        },
-        "@babel/helper-wrap-function": {
-          "version": "7.10.1",
-          "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.10.1.tgz",
-          "integrity": "sha512-C0MzRGteVDn+H32/ZgbAv5r56f2o1fZSA/rj/TYo8JEJNHg+9BdSmKBUND0shxWRztWhjlT2cvHYuynpPsVJwQ==",
-          "requires": {
-            "@babel/helper-function-name": "^7.10.1",
-            "@babel/template": "^7.10.1",
-            "@babel/traverse": "^7.10.1",
-            "@babel/types": "^7.10.1"
-          }
-        },
-        "@babel/helpers": {
-          "version": "7.10.1",
-          "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.10.1.tgz",
-          "integrity": "sha512-muQNHF+IdU6wGgkaJyhhEmI54MOZBKsFfsXFhboz1ybwJ1Kl7IHlbm2a++4jwrmY5UYsgitt5lfqo1wMFcHmyw==",
-          "requires": {
-            "@babel/template": "^7.10.1",
-            "@babel/traverse": "^7.10.1",
-            "@babel/types": "^7.10.1"
-          }
-        },
-        "@babel/highlight": {
-          "version": "7.10.1",
-          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.1.tgz",
-          "integrity": "sha512-8rMof+gVP8mxYZApLF/JgNDAkdKa+aJt3ZYxF8z6+j/hpeXL7iMsKCPHa2jNMHu/qqBwzQF4OHNoYi8dMA/rYg==",
-          "requires": {
-            "@babel/helper-validator-identifier": "^7.10.1",
-            "chalk": "^2.0.0",
-            "js-tokens": "^4.0.0"
-          }
-        },
-        "@babel/parser": {
-          "version": "7.10.2",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.10.2.tgz",
-          "integrity": "sha512-PApSXlNMJyB4JiGVhCOlzKIif+TKFTvu0aQAhnTvfP/z3vVSN6ZypH5bfUNwFXXjRQtUEBNFd2PtmCmG2Py3qQ=="
-        },
-        "@babel/plugin-proposal-async-generator-functions": {
-          "version": "7.10.1",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.10.1.tgz",
-          "integrity": "sha512-vzZE12ZTdB336POZjmpblWfNNRpMSua45EYnRigE2XsZxcXcIyly2ixnTJasJE4Zq3U7t2d8rRF7XRUuzHxbOw==",
-          "requires": {
-            "@babel/helper-plugin-utils": "^7.10.1",
-            "@babel/helper-remap-async-to-generator": "^7.10.1",
-            "@babel/plugin-syntax-async-generators": "^7.8.0"
-          }
-        },
-        "@babel/plugin-proposal-dynamic-import": {
-          "version": "7.10.1",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-dynamic-import/-/plugin-proposal-dynamic-import-7.10.1.tgz",
-          "integrity": "sha512-Cpc2yUVHTEGPlmiQzXj026kqwjEQAD9I4ZC16uzdbgWgitg/UHKHLffKNCQZ5+y8jpIZPJcKcwsr2HwPh+w3XA==",
-          "requires": {
-            "@babel/helper-plugin-utils": "^7.10.1",
-            "@babel/plugin-syntax-dynamic-import": "^7.8.0"
-          }
-        },
-        "@babel/plugin-proposal-json-strings": {
-          "version": "7.10.1",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.10.1.tgz",
-          "integrity": "sha512-m8r5BmV+ZLpWPtMY2mOKN7wre6HIO4gfIiV+eOmsnZABNenrt/kzYBwrh+KOfgumSWpnlGs5F70J8afYMSJMBg==",
-          "requires": {
-            "@babel/helper-plugin-utils": "^7.10.1",
-            "@babel/plugin-syntax-json-strings": "^7.8.0"
-          }
-        },
-        "@babel/plugin-proposal-nullish-coalescing-operator": {
-          "version": "7.10.1",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-nullish-coalescing-operator/-/plugin-proposal-nullish-coalescing-operator-7.10.1.tgz",
-          "integrity": "sha512-56cI/uHYgL2C8HVuHOuvVowihhX0sxb3nnfVRzUeVHTWmRHTZrKuAh/OBIMggGU/S1g/1D2CRCXqP+3u7vX7iA==",
-          "requires": {
-            "@babel/helper-plugin-utils": "^7.10.1",
-            "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.0"
-          }
-        },
-        "@babel/plugin-proposal-object-rest-spread": {
-          "version": "7.10.1",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.10.1.tgz",
-          "integrity": "sha512-Z+Qri55KiQkHh7Fc4BW6o+QBuTagbOp9txE+4U1i79u9oWlf2npkiDx+Rf3iK3lbcHBuNy9UOkwuR5wOMH3LIQ==",
-          "requires": {
-            "@babel/helper-plugin-utils": "^7.10.1",
-            "@babel/plugin-syntax-object-rest-spread": "^7.8.0",
-            "@babel/plugin-transform-parameters": "^7.10.1"
-          }
-        },
-        "@babel/plugin-proposal-optional-catch-binding": {
-          "version": "7.10.1",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.10.1.tgz",
-          "integrity": "sha512-VqExgeE62YBqI3ogkGoOJp1R6u12DFZjqwJhqtKc2o5m1YTUuUWnos7bZQFBhwkxIFpWYJ7uB75U7VAPPiKETA==",
-          "requires": {
-            "@babel/helper-plugin-utils": "^7.10.1",
-            "@babel/plugin-syntax-optional-catch-binding": "^7.8.0"
-          }
-        },
-        "@babel/plugin-proposal-optional-chaining": {
-          "version": "7.10.1",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.10.1.tgz",
-          "integrity": "sha512-dqQj475q8+/avvok72CF3AOSV/SGEcH29zT5hhohqqvvZ2+boQoOr7iGldBG5YXTO2qgCgc2B3WvVLUdbeMlGA==",
-          "requires": {
-            "@babel/helper-plugin-utils": "^7.10.1",
-            "@babel/plugin-syntax-optional-chaining": "^7.8.0"
-          }
-        },
-        "@babel/plugin-proposal-unicode-property-regex": {
-          "version": "7.10.1",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.10.1.tgz",
-          "integrity": "sha512-JjfngYRvwmPwmnbRZyNiPFI8zxCZb8euzbCG/LxyKdeTb59tVciKo9GK9bi6JYKInk1H11Dq9j/zRqIH4KigfQ==",
-          "requires": {
-            "@babel/helper-create-regexp-features-plugin": "^7.10.1",
-            "@babel/helper-plugin-utils": "^7.10.1"
-          }
-        },
-        "@babel/plugin-syntax-top-level-await": {
-          "version": "7.10.1",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.10.1.tgz",
-          "integrity": "sha512-hgA5RYkmZm8FTFT3yu2N9Bx7yVVOKYT6yEdXXo6j2JTm0wNxgqaGeQVaSHRjhfnQbX91DtjFB6McRFSlcJH3xQ==",
-          "requires": {
-            "@babel/helper-plugin-utils": "^7.10.1"
-          }
-        },
-        "@babel/plugin-syntax-typescript": {
-          "version": "7.10.1",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.10.1.tgz",
-          "integrity": "sha512-X/d8glkrAtra7CaQGMiGs/OGa6XgUzqPcBXCIGFCpCqnfGlT0Wfbzo/B89xHhnInTaItPK8LALblVXcUOEh95Q==",
-          "requires": {
-            "@babel/helper-plugin-utils": "^7.10.1"
-          }
-        },
-        "@babel/plugin-transform-arrow-functions": {
-          "version": "7.10.1",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.10.1.tgz",
-          "integrity": "sha512-6AZHgFJKP3DJX0eCNJj01RpytUa3SOGawIxweHkNX2L6PYikOZmoh5B0d7hIHaIgveMjX990IAa/xK7jRTN8OA==",
-          "requires": {
-            "@babel/helper-plugin-utils": "^7.10.1"
-          }
-        },
-        "@babel/plugin-transform-async-to-generator": {
-          "version": "7.10.1",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.10.1.tgz",
-          "integrity": "sha512-XCgYjJ8TY2slj6SReBUyamJn3k2JLUIiiR5b6t1mNCMSvv7yx+jJpaewakikp0uWFQSF7ChPPoe3dHmXLpISkg==",
-          "requires": {
-            "@babel/helper-module-imports": "^7.10.1",
-            "@babel/helper-plugin-utils": "^7.10.1",
-            "@babel/helper-remap-async-to-generator": "^7.10.1"
-          }
-        },
-        "@babel/plugin-transform-block-scoped-functions": {
-          "version": "7.10.1",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.10.1.tgz",
-          "integrity": "sha512-B7K15Xp8lv0sOJrdVAoukKlxP9N59HS48V1J3U/JGj+Ad+MHq+am6xJVs85AgXrQn4LV8vaYFOB+pr/yIuzW8Q==",
-          "requires": {
-            "@babel/helper-plugin-utils": "^7.10.1"
-          }
-        },
-        "@babel/plugin-transform-block-scoping": {
-          "version": "7.10.1",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.10.1.tgz",
-          "integrity": "sha512-8bpWG6TtF5akdhIm/uWTyjHqENpy13Fx8chg7pFH875aNLwX8JxIxqm08gmAT+Whe6AOmaTeLPe7dpLbXt+xUw==",
-          "requires": {
-            "@babel/helper-plugin-utils": "^7.10.1",
-            "lodash": "^4.17.13"
-          }
-        },
-        "@babel/plugin-transform-classes": {
-          "version": "7.10.1",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.10.1.tgz",
-          "integrity": "sha512-P9V0YIh+ln/B3RStPoXpEQ/CoAxQIhRSUn7aXqQ+FZJ2u8+oCtjIXR3+X0vsSD8zv+mb56K7wZW1XiDTDGiDRQ==",
-          "requires": {
-            "@babel/helper-annotate-as-pure": "^7.10.1",
-            "@babel/helper-define-map": "^7.10.1",
-            "@babel/helper-function-name": "^7.10.1",
-            "@babel/helper-optimise-call-expression": "^7.10.1",
-            "@babel/helper-plugin-utils": "^7.10.1",
-            "@babel/helper-replace-supers": "^7.10.1",
-            "@babel/helper-split-export-declaration": "^7.10.1",
-            "globals": "^11.1.0"
-          }
-        },
-        "@babel/plugin-transform-computed-properties": {
-          "version": "7.10.1",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.10.1.tgz",
-          "integrity": "sha512-mqSrGjp3IefMsXIenBfGcPXxJxweQe2hEIwMQvjtiDQ9b1IBvDUjkAtV/HMXX47/vXf14qDNedXsIiNd1FmkaQ==",
-          "requires": {
-            "@babel/helper-plugin-utils": "^7.10.1"
-          }
-        },
-        "@babel/plugin-transform-destructuring": {
-          "version": "7.10.1",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.10.1.tgz",
-          "integrity": "sha512-V/nUc4yGWG71OhaTH705pU8ZSdM6c1KmmLP8ys59oOYbT7RpMYAR3MsVOt6OHL0WzG7BlTU076va9fjJyYzJMA==",
-          "requires": {
-            "@babel/helper-plugin-utils": "^7.10.1"
-          }
-        },
-        "@babel/plugin-transform-dotall-regex": {
-          "version": "7.10.1",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.10.1.tgz",
-          "integrity": "sha512-19VIMsD1dp02RvduFUmfzj8uknaO3uiHHF0s3E1OHnVsNj8oge8EQ5RzHRbJjGSetRnkEuBYO7TG1M5kKjGLOA==",
-          "requires": {
-            "@babel/helper-create-regexp-features-plugin": "^7.10.1",
-            "@babel/helper-plugin-utils": "^7.10.1"
-          }
-        },
-        "@babel/plugin-transform-duplicate-keys": {
-          "version": "7.10.1",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.10.1.tgz",
-          "integrity": "sha512-wIEpkX4QvX8Mo9W6XF3EdGttrIPZWozHfEaDTU0WJD/TDnXMvdDh30mzUl/9qWhnf7naicYartcEfUghTCSNpA==",
-          "requires": {
-            "@babel/helper-plugin-utils": "^7.10.1"
-          }
-        },
-        "@babel/plugin-transform-exponentiation-operator": {
-          "version": "7.10.1",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.10.1.tgz",
-          "integrity": "sha512-lr/przdAbpEA2BUzRvjXdEDLrArGRRPwbaF9rvayuHRvdQ7lUTTkZnhZrJ4LE2jvgMRFF4f0YuPQ20vhiPYxtA==",
-          "requires": {
-            "@babel/helper-builder-binary-assignment-operator-visitor": "^7.10.1",
-            "@babel/helper-plugin-utils": "^7.10.1"
-          }
-        },
-        "@babel/plugin-transform-for-of": {
-          "version": "7.10.1",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.10.1.tgz",
-          "integrity": "sha512-US8KCuxfQcn0LwSCMWMma8M2R5mAjJGsmoCBVwlMygvmDUMkTCykc84IqN1M7t+agSfOmLYTInLCHJM+RUoz+w==",
-          "requires": {
-            "@babel/helper-plugin-utils": "^7.10.1"
-          }
-        },
-        "@babel/plugin-transform-function-name": {
-          "version": "7.10.1",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.10.1.tgz",
-          "integrity": "sha512-//bsKsKFBJfGd65qSNNh1exBy5Y9gD9ZN+DvrJ8f7HXr4avE5POW6zB7Rj6VnqHV33+0vXWUwJT0wSHubiAQkw==",
-          "requires": {
-            "@babel/helper-function-name": "^7.10.1",
-            "@babel/helper-plugin-utils": "^7.10.1"
-          }
-        },
-        "@babel/plugin-transform-literals": {
-          "version": "7.10.1",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.10.1.tgz",
-          "integrity": "sha512-qi0+5qgevz1NHLZroObRm5A+8JJtibb7vdcPQF1KQE12+Y/xxl8coJ+TpPW9iRq+Mhw/NKLjm+5SHtAHCC7lAw==",
-          "requires": {
-            "@babel/helper-plugin-utils": "^7.10.1"
-          }
-        },
-        "@babel/plugin-transform-member-expression-literals": {
-          "version": "7.10.1",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.10.1.tgz",
-          "integrity": "sha512-UmaWhDokOFT2GcgU6MkHC11i0NQcL63iqeufXWfRy6pUOGYeCGEKhvfFO6Vz70UfYJYHwveg62GS83Rvpxn+NA==",
-          "requires": {
-            "@babel/helper-plugin-utils": "^7.10.1"
-          }
-        },
-        "@babel/plugin-transform-modules-amd": {
-          "version": "7.10.1",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.10.1.tgz",
-          "integrity": "sha512-31+hnWSFRI4/ACFr1qkboBbrTxoBIzj7qA69qlq8HY8p7+YCzkCT6/TvQ1a4B0z27VeWtAeJd6pr5G04dc1iHw==",
-          "requires": {
-            "@babel/helper-module-transforms": "^7.10.1",
-            "@babel/helper-plugin-utils": "^7.10.1",
-            "babel-plugin-dynamic-import-node": "^2.3.3"
-          }
-        },
-        "@babel/plugin-transform-modules-commonjs": {
-          "version": "7.10.1",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.10.1.tgz",
-          "integrity": "sha512-AQG4fc3KOah0vdITwt7Gi6hD9BtQP/8bhem7OjbaMoRNCH5Djx42O2vYMfau7QnAzQCa+RJnhJBmFFMGpQEzrg==",
-          "requires": {
-            "@babel/helper-module-transforms": "^7.10.1",
-            "@babel/helper-plugin-utils": "^7.10.1",
-            "@babel/helper-simple-access": "^7.10.1",
-            "babel-plugin-dynamic-import-node": "^2.3.3"
-          }
-        },
-        "@babel/plugin-transform-modules-systemjs": {
-          "version": "7.10.1",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.10.1.tgz",
-          "integrity": "sha512-ewNKcj1TQZDL3YnO85qh9zo1YF1CHgmSTlRQgHqe63oTrMI85cthKtZjAiZSsSNjPQ5NCaYo5QkbYqEw1ZBgZA==",
-          "requires": {
-            "@babel/helper-hoist-variables": "^7.10.1",
-            "@babel/helper-module-transforms": "^7.10.1",
-            "@babel/helper-plugin-utils": "^7.10.1",
-            "babel-plugin-dynamic-import-node": "^2.3.3"
-          }
-        },
-        "@babel/plugin-transform-modules-umd": {
-          "version": "7.10.1",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.10.1.tgz",
-          "integrity": "sha512-EIuiRNMd6GB6ulcYlETnYYfgv4AxqrswghmBRQbWLHZxN4s7mupxzglnHqk9ZiUpDI4eRWewedJJNj67PWOXKA==",
-          "requires": {
-            "@babel/helper-module-transforms": "^7.10.1",
-            "@babel/helper-plugin-utils": "^7.10.1"
-          }
-        },
-        "@babel/plugin-transform-new-target": {
-          "version": "7.10.1",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.10.1.tgz",
-          "integrity": "sha512-MBlzPc1nJvbmO9rPr1fQwXOM2iGut+JC92ku6PbiJMMK7SnQc1rytgpopveE3Evn47gzvGYeCdgfCDbZo0ecUw==",
-          "requires": {
-            "@babel/helper-plugin-utils": "^7.10.1"
-          }
-        },
-        "@babel/plugin-transform-object-super": {
-          "version": "7.10.1",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.10.1.tgz",
-          "integrity": "sha512-WnnStUDN5GL+wGQrJylrnnVlFhFmeArINIR9gjhSeYyvroGhBrSAXYg/RHsnfzmsa+onJrTJrEClPzgNmmQ4Gw==",
-          "requires": {
-            "@babel/helper-plugin-utils": "^7.10.1",
-            "@babel/helper-replace-supers": "^7.10.1"
-          }
-        },
-        "@babel/plugin-transform-parameters": {
-          "version": "7.10.1",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.10.1.tgz",
-          "integrity": "sha512-tJ1T0n6g4dXMsL45YsSzzSDZCxiHXAQp/qHrucOq5gEHncTA3xDxnd5+sZcoQp+N1ZbieAaB8r/VUCG0gqseOg==",
-          "requires": {
-            "@babel/helper-get-function-arity": "^7.10.1",
-            "@babel/helper-plugin-utils": "^7.10.1"
-          }
-        },
-        "@babel/plugin-transform-property-literals": {
-          "version": "7.10.1",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.10.1.tgz",
-          "integrity": "sha512-Kr6+mgag8auNrgEpbfIWzdXYOvqDHZOF0+Bx2xh4H2EDNwcbRb9lY6nkZg8oSjsX+DH9Ebxm9hOqtKW+gRDeNA==",
-          "requires": {
-            "@babel/helper-plugin-utils": "^7.10.1"
-          }
-        },
-        "@babel/plugin-transform-regenerator": {
-          "version": "7.10.1",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.10.1.tgz",
-          "integrity": "sha512-B3+Y2prScgJ2Bh/2l9LJxKbb8C8kRfsG4AdPT+n7ixBHIxJaIG8bi8tgjxUMege1+WqSJ+7gu1YeoMVO3gPWzw==",
-          "requires": {
-            "regenerator-transform": "^0.14.2"
-          }
-        },
-        "@babel/plugin-transform-reserved-words": {
-          "version": "7.10.1",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.10.1.tgz",
-          "integrity": "sha512-qN1OMoE2nuqSPmpTqEM7OvJ1FkMEV+BjVeZZm9V9mq/x1JLKQ4pcv8riZJMNN3u2AUGl0ouOMjRr2siecvHqUQ==",
-          "requires": {
-            "@babel/helper-plugin-utils": "^7.10.1"
-          }
-        },
-        "@babel/plugin-transform-runtime": {
-          "version": "7.10.1",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.10.1.tgz",
-          "integrity": "sha512-4w2tcglDVEwXJ5qxsY++DgWQdNJcCCsPxfT34wCUwIf2E7dI7pMpH8JczkMBbgBTNzBX62SZlNJ9H+De6Zebaw==",
-          "requires": {
-            "@babel/helper-module-imports": "^7.10.1",
-            "@babel/helper-plugin-utils": "^7.10.1",
-            "resolve": "^1.8.1",
-            "semver": "^5.5.1"
-          }
-        },
-        "@babel/plugin-transform-shorthand-properties": {
-          "version": "7.10.1",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.10.1.tgz",
-          "integrity": "sha512-AR0E/lZMfLstScFwztApGeyTHJ5u3JUKMjneqRItWeEqDdHWZwAOKycvQNCasCK/3r5YXsuNG25funcJDu7Y2g==",
-          "requires": {
-            "@babel/helper-plugin-utils": "^7.10.1"
-          }
-        },
-        "@babel/plugin-transform-spread": {
-          "version": "7.10.1",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.10.1.tgz",
-          "integrity": "sha512-8wTPym6edIrClW8FI2IoaePB91ETOtg36dOkj3bYcNe7aDMN2FXEoUa+WrmPc4xa1u2PQK46fUX2aCb+zo9rfw==",
-          "requires": {
-            "@babel/helper-plugin-utils": "^7.10.1"
-          }
-        },
-        "@babel/plugin-transform-sticky-regex": {
-          "version": "7.10.1",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.10.1.tgz",
-          "integrity": "sha512-j17ojftKjrL7ufX8ajKvwRilwqTok4q+BjkknmQw9VNHnItTyMP5anPFzxFJdCQs7clLcWpCV3ma+6qZWLnGMA==",
-          "requires": {
-            "@babel/helper-plugin-utils": "^7.10.1",
-            "@babel/helper-regex": "^7.10.1"
-          }
-        },
-        "@babel/plugin-transform-template-literals": {
-          "version": "7.10.1",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.10.1.tgz",
-          "integrity": "sha512-t7B/3MQf5M1T9hPCRG28DNGZUuxAuDqLYS03rJrIk2prj/UV7Z6FOneijhQhnv/Xa039vidXeVbvjK2SK5f7Gg==",
-          "requires": {
-            "@babel/helper-annotate-as-pure": "^7.10.1",
-            "@babel/helper-plugin-utils": "^7.10.1"
-          }
-        },
-        "@babel/plugin-transform-typeof-symbol": {
-          "version": "7.10.1",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.10.1.tgz",
-          "integrity": "sha512-qX8KZcmbvA23zDi+lk9s6hC1FM7jgLHYIjuLgULgc8QtYnmB3tAVIYkNoKRQ75qWBeyzcoMoK8ZQmogGtC/w0g==",
-          "requires": {
-            "@babel/helper-plugin-utils": "^7.10.1"
-          }
-        },
-        "@babel/plugin-transform-typescript": {
-          "version": "7.10.1",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.10.1.tgz",
-          "integrity": "sha512-v+QWKlmCnsaimLeqq9vyCsVRMViZG1k2SZTlcZvB+TqyH570Zsij8nvVUZzOASCRiQFUxkLrn9Wg/kH0zgy5OQ==",
-          "requires": {
-            "@babel/helper-create-class-features-plugin": "^7.10.1",
-            "@babel/helper-plugin-utils": "^7.10.1",
-            "@babel/plugin-syntax-typescript": "^7.10.1"
-          }
-        },
-        "@babel/plugin-transform-unicode-regex": {
-          "version": "7.10.1",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.10.1.tgz",
-          "integrity": "sha512-Y/2a2W299k0VIUdbqYm9X2qS6fE0CUBhhiPpimK6byy7OJ/kORLlIX+J6UrjgNu5awvs62k+6RSslxhcvVw2Tw==",
-          "requires": {
-            "@babel/helper-create-regexp-features-plugin": "^7.10.1",
-            "@babel/helper-plugin-utils": "^7.10.1"
-          }
-        },
-        "@babel/polyfill": {
-          "version": "7.10.1",
-          "resolved": "https://registry.npmjs.org/@babel/polyfill/-/polyfill-7.10.1.tgz",
-          "integrity": "sha512-TviueJ4PBW5p48ra8IMtLXVkDucrlOZAIZ+EXqS3Ot4eukHbWiqcn7DcqpA1k5PcKtmJ4Xl9xwdv6yQvvcA+3g==",
-          "requires": {
-            "core-js": "^2.6.5",
-            "regenerator-runtime": "^0.13.4"
-          }
-        },
-        "@babel/preset-env": {
-          "version": "7.10.2",
-          "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.10.2.tgz",
-          "integrity": "sha512-MjqhX0RZaEgK/KueRzh+3yPSk30oqDKJ5HP5tqTSB1e2gzGS3PLy7K0BIpnp78+0anFuSwOeuCf1zZO7RzRvEA==",
-          "requires": {
-            "@babel/compat-data": "^7.10.1",
-            "@babel/helper-compilation-targets": "^7.10.2",
-            "@babel/helper-module-imports": "^7.10.1",
-            "@babel/helper-plugin-utils": "^7.10.1",
-            "@babel/plugin-proposal-async-generator-functions": "^7.10.1",
-            "@babel/plugin-proposal-class-properties": "^7.10.1",
-            "@babel/plugin-proposal-dynamic-import": "^7.10.1",
-            "@babel/plugin-proposal-json-strings": "^7.10.1",
-            "@babel/plugin-proposal-nullish-coalescing-operator": "^7.10.1",
-            "@babel/plugin-proposal-numeric-separator": "^7.10.1",
-            "@babel/plugin-proposal-object-rest-spread": "^7.10.1",
-            "@babel/plugin-proposal-optional-catch-binding": "^7.10.1",
-            "@babel/plugin-proposal-optional-chaining": "^7.10.1",
-            "@babel/plugin-proposal-private-methods": "^7.10.1",
-            "@babel/plugin-proposal-unicode-property-regex": "^7.10.1",
-            "@babel/plugin-syntax-async-generators": "^7.8.0",
-            "@babel/plugin-syntax-class-properties": "^7.10.1",
-            "@babel/plugin-syntax-dynamic-import": "^7.8.0",
-            "@babel/plugin-syntax-json-strings": "^7.8.0",
-            "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.0",
-            "@babel/plugin-syntax-numeric-separator": "^7.10.1",
-            "@babel/plugin-syntax-object-rest-spread": "^7.8.0",
-            "@babel/plugin-syntax-optional-catch-binding": "^7.8.0",
-            "@babel/plugin-syntax-optional-chaining": "^7.8.0",
-            "@babel/plugin-syntax-top-level-await": "^7.10.1",
-            "@babel/plugin-transform-arrow-functions": "^7.10.1",
-            "@babel/plugin-transform-async-to-generator": "^7.10.1",
-            "@babel/plugin-transform-block-scoped-functions": "^7.10.1",
-            "@babel/plugin-transform-block-scoping": "^7.10.1",
-            "@babel/plugin-transform-classes": "^7.10.1",
-            "@babel/plugin-transform-computed-properties": "^7.10.1",
-            "@babel/plugin-transform-destructuring": "^7.10.1",
-            "@babel/plugin-transform-dotall-regex": "^7.10.1",
-            "@babel/plugin-transform-duplicate-keys": "^7.10.1",
-            "@babel/plugin-transform-exponentiation-operator": "^7.10.1",
-            "@babel/plugin-transform-for-of": "^7.10.1",
-            "@babel/plugin-transform-function-name": "^7.10.1",
-            "@babel/plugin-transform-literals": "^7.10.1",
-            "@babel/plugin-transform-member-expression-literals": "^7.10.1",
-            "@babel/plugin-transform-modules-amd": "^7.10.1",
-            "@babel/plugin-transform-modules-commonjs": "^7.10.1",
-            "@babel/plugin-transform-modules-systemjs": "^7.10.1",
-            "@babel/plugin-transform-modules-umd": "^7.10.1",
-            "@babel/plugin-transform-named-capturing-groups-regex": "^7.8.3",
-            "@babel/plugin-transform-new-target": "^7.10.1",
-            "@babel/plugin-transform-object-super": "^7.10.1",
-            "@babel/plugin-transform-parameters": "^7.10.1",
-            "@babel/plugin-transform-property-literals": "^7.10.1",
-            "@babel/plugin-transform-regenerator": "^7.10.1",
-            "@babel/plugin-transform-reserved-words": "^7.10.1",
-            "@babel/plugin-transform-shorthand-properties": "^7.10.1",
-            "@babel/plugin-transform-spread": "^7.10.1",
-            "@babel/plugin-transform-sticky-regex": "^7.10.1",
-            "@babel/plugin-transform-template-literals": "^7.10.1",
-            "@babel/plugin-transform-typeof-symbol": "^7.10.1",
-            "@babel/plugin-transform-unicode-escapes": "^7.10.1",
-            "@babel/plugin-transform-unicode-regex": "^7.10.1",
-            "@babel/preset-modules": "^0.1.3",
-            "@babel/types": "^7.10.2",
-            "browserslist": "^4.12.0",
-            "core-js-compat": "^3.6.2",
-            "invariant": "^2.2.2",
-            "levenary": "^1.1.1",
-            "semver": "^5.5.0"
-          },
-          "dependencies": {
-            "@babel/plugin-proposal-class-properties": {
-              "version": "7.10.1",
-              "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.10.1.tgz",
-              "integrity": "sha512-sqdGWgoXlnOdgMXU+9MbhzwFRgxVLeiGBqTrnuS7LC2IBU31wSsESbTUreT2O418obpfPdGUR2GbEufZF1bpqw==",
-              "requires": {
-                "@babel/helper-create-class-features-plugin": "^7.10.1",
-                "@babel/helper-plugin-utils": "^7.10.1"
-              }
-            }
-          }
-        },
-        "@babel/runtime": {
-          "version": "7.10.2",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.10.2.tgz",
-          "integrity": "sha512-6sF3uQw2ivImfVIl62RZ7MXhO2tap69WeWK57vAaimT6AZbE4FbqjdEJIN1UqoD6wI6B+1n9UiagafH1sxjOtg==",
-          "requires": {
-            "regenerator-runtime": "^0.13.4"
-          }
-        },
-        "@babel/template": {
-          "version": "7.10.1",
-          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.10.1.tgz",
-          "integrity": "sha512-OQDg6SqvFSsc9A0ej6SKINWrpJiNonRIniYondK2ViKhB06i3c0s+76XUft71iqBEe9S1OKsHwPAjfHnuvnCig==",
-          "requires": {
-            "@babel/code-frame": "^7.10.1",
-            "@babel/parser": "^7.10.1",
-            "@babel/types": "^7.10.1"
-          }
-        },
-        "@babel/traverse": {
-          "version": "7.10.1",
-          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.10.1.tgz",
-          "integrity": "sha512-C/cTuXeKt85K+p08jN6vMDz8vSV0vZcI0wmQ36o6mjbuo++kPMdpOYw23W2XH04dbRt9/nMEfA4W3eR21CD+TQ==",
-          "requires": {
-            "@babel/code-frame": "^7.10.1",
-            "@babel/generator": "^7.10.1",
-            "@babel/helper-function-name": "^7.10.1",
-            "@babel/helper-split-export-declaration": "^7.10.1",
-            "@babel/parser": "^7.10.1",
-            "@babel/types": "^7.10.1",
-            "debug": "^4.1.0",
-            "globals": "^11.1.0",
-            "lodash": "^4.17.13"
-          }
-        },
-        "@babel/types": {
-          "version": "7.10.2",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.10.2.tgz",
-          "integrity": "sha512-AD3AwWBSz0AWF0AkCN9VPiWrvldXq+/e3cHa4J89vo4ymjz1XwrBFFVZmkJTsQIPNk+ZVomPSXUJqq8yyjZsng==",
-          "requires": {
-            "@babel/helper-validator-identifier": "^7.10.1",
-            "lodash": "^4.17.13",
-            "to-fast-properties": "^2.0.0"
-          }
-        },
-        "babel-plugin-dynamic-import-node": {
-          "version": "2.3.3",
-          "resolved": "https://registry.npmjs.org/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.3.tgz",
-          "integrity": "sha512-jZVI+s9Zg3IqA/kdi0i6UDCybUI3aSBLnglhYbSSjKlV7yF1F/5LWv8MakQmvYpnbJDS6fcBL2KzHSxNCMtWSQ==",
-          "requires": {
-            "object.assign": "^4.1.0"
-          }
-        },
-        "babel-plugin-ember-data-packages-polyfill": {
-          "version": "0.1.2",
-          "resolved": "https://registry.npmjs.org/babel-plugin-ember-data-packages-polyfill/-/babel-plugin-ember-data-packages-polyfill-0.1.2.tgz",
-          "integrity": "sha512-kTHnOwoOXfPXi00Z8yAgyD64+jdSXk3pknnS7NlqnCKAU6YDkXZ4Y7irl66kaZjZn0FBBt0P4YOZFZk85jYOww==",
-          "requires": {
-            "@ember-data/rfc395-data": "^0.0.4"
-          }
-        },
-        "babel-plugin-ember-modules-api-polyfill": {
-          "version": "2.13.4",
-          "resolved": "https://registry.npmjs.org/babel-plugin-ember-modules-api-polyfill/-/babel-plugin-ember-modules-api-polyfill-2.13.4.tgz",
-          "integrity": "sha512-uxQPkEQAzCYdwhZk16O9m1R4xtCRNy4oEUTBrccOPfzlIahRZJic/JeP/ZEL0BC6Mfq6r55eOg6gMF/zdFoCvA==",
-          "requires": {
-            "ember-rfc176-data": "^0.3.13"
-          }
-        },
-        "babel-plugin-htmlbars-inline-precompile": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/babel-plugin-htmlbars-inline-precompile/-/babel-plugin-htmlbars-inline-precompile-3.1.0.tgz",
-          "integrity": "sha512-ar6c4YVX6OV7Dzpq7xRyllQrHwVEzJf41qysYULnD6tu6TS+y1FxT2VcEvMC6b9Rq9xoHMzvB79HO3av89JCGg=="
-        },
-        "broccoli-plugin": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-3.1.0.tgz",
-          "integrity": "sha512-7w7FP8WJYjLvb0eaw27LO678TGGaom++49O1VYIuzjhXjK5kn2+AMlDm7CaUFw4F7CLGoVQeZ84d8gICMJa4lA==",
-          "requires": {
-            "broccoli-node-api": "^1.6.0",
-            "broccoli-output-wrapper": "^2.0.0",
-            "fs-merger": "^3.0.1",
-            "promise-map-series": "^0.2.1",
-            "quick-temp": "^0.1.3",
-            "rimraf": "^2.3.4",
-            "symlink-or-copy": "^1.1.8"
-          },
-          "dependencies": {
-            "rimraf": {
-              "version": "2.7.1",
-              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-              "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-              "requires": {
-                "glob": "^7.1.3"
-              }
-            }
-          }
-        },
-        "browserslist": {
-          "version": "4.12.0",
-          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.12.0.tgz",
-          "integrity": "sha512-UH2GkcEDSI0k/lRkuDSzFl9ZZ87skSy9w2XAn1MsZnL+4c4rqbBd3e82UWHbYDpztABrPBhZsTEeuxVfHppqDg==",
-          "requires": {
-            "caniuse-lite": "^1.0.30001043",
-            "electron-to-chromium": "^1.3.413",
-            "node-releases": "^1.1.53",
-            "pkg-up": "^2.0.0"
-          }
-        },
-        "caniuse-lite": {
-          "version": "1.0.30001077",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001077.tgz",
-          "integrity": "sha512-AEzsGvjBJL0lby/87W96PyEvwN0GsYvk5LHsglLg9tW37K4BqvAvoSCdWIE13OZQ8afupqZ73+oL/1LkedN8hA=="
-        },
-        "electron-to-chromium": {
-          "version": "1.3.458",
-          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.458.tgz",
-          "integrity": "sha512-OjRkb0igW0oKE2QbzS7vBYrm7xjW/KRTtIj0OGGx57jr/YhBiKb7oZvdbaojqjfCb/7LbnwsbMbdsYjthdJbAw=="
-        },
-        "ember-cli-babel": {
-          "version": "7.20.5",
-          "resolved": "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-7.20.5.tgz",
-          "integrity": "sha512-lWvKqJPQ1KJigWKmxREqFbXgZd2/nFKMg3chiiNejpsAIgGLPXGFLwpMQ7QYCRrlims7D/bnDgFvXuOLkw0fcQ==",
-          "requires": {
-            "@babel/core": "^7.9.0",
-            "@babel/helper-compilation-targets": "^7.8.7",
-            "@babel/plugin-proposal-class-properties": "^7.8.3",
-            "@babel/plugin-proposal-decorators": "^7.8.3",
-            "@babel/plugin-transform-modules-amd": "^7.9.0",
-            "@babel/plugin-transform-runtime": "^7.9.0",
-            "@babel/plugin-transform-typescript": "^7.9.0",
-            "@babel/polyfill": "^7.8.7",
-            "@babel/preset-env": "^7.9.0",
-            "@babel/runtime": "^7.9.0",
-            "amd-name-resolver": "^1.2.1",
-            "babel-plugin-debug-macros": "^0.3.0",
-            "babel-plugin-ember-data-packages-polyfill": "^0.1.2",
-            "babel-plugin-ember-modules-api-polyfill": "^2.13.4",
-            "babel-plugin-module-resolver": "^3.1.1",
-            "broccoli-babel-transpiler": "^7.4.0",
-            "broccoli-debug": "^0.6.4",
-            "broccoli-funnel": "^2.0.1",
-            "broccoli-source": "^1.1.0",
-            "clone": "^2.1.2",
-            "ember-cli-babel-plugin-helpers": "^1.1.0",
-            "ember-cli-version-checker": "^4.1.0",
-            "ensure-posix-path": "^1.0.2",
-            "fixturify-project": "^1.10.0",
-            "rimraf": "^3.0.1",
-            "semver": "^5.5.0"
-          }
-        },
-        "ember-cli-htmlbars": {
-          "version": "4.3.1",
-          "resolved": "https://registry.npmjs.org/ember-cli-htmlbars/-/ember-cli-htmlbars-4.3.1.tgz",
-          "integrity": "sha512-CW6AY/yzjeVqoRtItOKj3hcYzc5dWPRETmeCzr2Iqjt5vxiVtpl0z5VTqHqIlT5fsFx6sGWBQXNHIe+ivYsxXQ==",
-          "requires": {
-            "@ember/edition-utils": "^1.2.0",
-            "babel-plugin-htmlbars-inline-precompile": "^3.0.1",
-            "broccoli-debug": "^0.6.5",
-            "broccoli-persistent-filter": "^2.3.1",
-            "broccoli-plugin": "^3.1.0",
-            "common-tags": "^1.8.0",
-            "ember-cli-babel-plugin-helpers": "^1.1.0",
-            "fs-tree-diff": "^2.0.1",
-            "hash-for-dep": "^1.5.1",
-            "heimdalljs-logger": "^0.1.10",
-            "json-stable-stringify": "^1.0.1",
-            "semver": "^6.3.0",
-            "strip-bom": "^4.0.0",
-            "walk-sync": "^2.0.2"
-          },
-          "dependencies": {
-            "semver": {
-              "version": "6.3.0",
-              "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-              "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
-            }
-          }
-        },
-        "ember-rfc176-data": {
-          "version": "0.3.13",
-          "resolved": "https://registry.npmjs.org/ember-rfc176-data/-/ember-rfc176-data-0.3.13.tgz",
-          "integrity": "sha512-m9JbwQlT6PjY7x/T8HslnXP7Sz9bx/pz3FrNfNi2NesJnbNISly0Lix6NV1fhfo46572cpq4jrM+/6yYlMefTQ=="
-        },
-        "fs-tree-diff": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/fs-tree-diff/-/fs-tree-diff-2.0.1.tgz",
-          "integrity": "sha512-x+CfAZ/lJHQqwlD64pYM5QxWjzWhSjroaVsr8PW831zOApL55qPibed0c+xebaLWVr2BnHFoHdrwOv8pzt8R5A==",
-          "requires": {
-            "@types/symlink-or-copy": "^1.2.0",
-            "heimdalljs-logger": "^0.1.7",
-            "object-assign": "^4.1.0",
-            "path-posix": "^1.0.0",
-            "symlink-or-copy": "^1.1.8"
-          }
-        },
-        "json5": {
-          "version": "2.1.3",
-          "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.3.tgz",
-          "integrity": "sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==",
-          "requires": {
-            "minimist": "^1.2.5"
-          }
-        },
-        "matcher-collection": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/matcher-collection/-/matcher-collection-2.0.1.tgz",
-          "integrity": "sha512-daE62nS2ZQsDg9raM0IlZzLmI2u+7ZapXBwdoeBUKAYERPDDIc0qNqA8E0Rp2D+gspKR7BgIFP52GeujaGXWeQ==",
-          "requires": {
-            "@types/minimatch": "^3.0.3",
-            "minimatch": "^3.0.2"
-          }
-        },
-        "minimist": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
-        },
-        "node-releases": {
-          "version": "1.1.58",
-          "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.58.tgz",
-          "integrity": "sha512-NxBudgVKiRh/2aPWMgPR7bPTX0VPmGx5QBwCtdHitnqFE5/O8DeBXuIMH1nwNnw/aMo6AjOrpsHzfY3UbUJ7yg=="
-        },
-        "regenerate-unicode-properties": {
-          "version": "8.2.0",
-          "resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-8.2.0.tgz",
-          "integrity": "sha512-F9DjY1vKLo/tPePDycuH3dn9H1OTPIkVD9Kz4LODu+F2C75mgjAJ7x/gwy6ZcSNRAAkhNlJSOHRe8k3p+K9WhA==",
-          "requires": {
-            "regenerate": "^1.4.0"
-          }
-        },
-        "regenerator-runtime": {
-          "version": "0.13.5",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
-          "integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA=="
-        },
-        "regenerator-transform": {
-          "version": "0.14.4",
-          "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.14.4.tgz",
-          "integrity": "sha512-EaJaKPBI9GvKpvUz2mz4fhx7WPgvwRLY9v3hlNHWmAuJHI13T4nwKnNvm5RWJzEdnI5g5UwtOww+S8IdoUC2bw==",
-          "requires": {
-            "@babel/runtime": "^7.8.4",
-            "private": "^0.1.8"
-          }
-        },
-        "regexpu-core": {
-          "version": "4.7.0",
-          "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.7.0.tgz",
-          "integrity": "sha512-TQ4KXRnIn6tz6tjnrXEkD/sshygKH/j5KzK86X8MkeHyZ8qst/LZ89j3X4/8HEIfHANTFIP/AbXakeRhWIl5YQ==",
-          "requires": {
-            "regenerate": "^1.4.0",
-            "regenerate-unicode-properties": "^8.2.0",
-            "regjsgen": "^0.5.1",
-            "regjsparser": "^0.6.4",
-            "unicode-match-property-ecmascript": "^1.0.4",
-            "unicode-match-property-value-ecmascript": "^1.2.0"
-          }
-        },
-        "regjsparser": {
-          "version": "0.6.4",
-          "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.6.4.tgz",
-          "integrity": "sha512-64O87/dPDgfk8/RQqC4gkZoGyyWFIEUTTh80CU6CWuK5vkCGyekIx+oKcEIYtP/RAxSQltCZHCNu/mdd7fqlJw==",
-          "requires": {
-            "jsesc": "~0.5.0"
-          },
-          "dependencies": {
-            "jsesc": {
-              "version": "0.5.0",
-              "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
-              "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0="
-            }
-          }
-        },
-        "strip-bom": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
-          "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w=="
-        },
-        "unicode-match-property-value-ecmascript": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-1.2.0.tgz",
-          "integrity": "sha512-wjuQHGQVofmSJv1uVISKLE5zO2rNGzM/KCYZch/QQvez7C1hUhBIuZ701fYXExuufJFMPhv2SyL8CyoIfMLbIQ=="
-        },
-        "walk-sync": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-2.1.0.tgz",
-          "integrity": "sha512-KpH9Xw64LNSx7/UI+3guRZvJWlDxVA4+KKb/4puRoVrG8GkvZRxnF3vhxdjgpoKJGL2TVg1OrtkXIE/VuGPLHQ==",
-          "requires": {
-            "@types/minimatch": "^3.0.3",
-            "ensure-posix-path": "^1.1.0",
-            "matcher-collection": "^2.0.0"
-          }
-        }
-      }
-    },
     "ember-cli-htmlbars": {
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/ember-cli-htmlbars/-/ember-cli-htmlbars-5.3.1.tgz",
       "integrity": "sha512-ZjQTt44euDoqLvUkWbt1svgNCXgLzOztEbc2qqYMQvhQig416LMrWK7l3SSbNU+BtLD5UIxmwvLfF1tsO2CVyA==",
+      "dev": true,
       "requires": {
         "@ember/edition-utils": "^1.2.0",
         "babel-plugin-htmlbars-inline-precompile": "^4.2.0",
@@ -11952,6 +13438,7 @@
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/async-disk-cache/-/async-disk-cache-2.1.0.tgz",
           "integrity": "sha512-iH+boep2xivfD9wMaZWkywYIURSmsL96d6MoqrC94BnGSvXE4Quf8hnJiHGFYhw/nLeIa1XyRaf4vvcvkwAefg==",
+          "dev": true,
           "requires": {
             "debug": "^4.1.1",
             "heimdalljs": "^0.2.3",
@@ -11965,12 +13452,14 @@
         "babel-plugin-htmlbars-inline-precompile": {
           "version": "4.2.0",
           "resolved": "https://registry.npmjs.org/babel-plugin-htmlbars-inline-precompile/-/babel-plugin-htmlbars-inline-precompile-4.2.0.tgz",
-          "integrity": "sha512-n2jMGcFKvubnYi8Ink7zJnC+aQor97v5FJKYUOUKijj5gIDy/sOIAZ7BxDWb0co1VzZokdN7tvtLnQtiWfD1Gw=="
+          "integrity": "sha512-n2jMGcFKvubnYi8Ink7zJnC+aQor97v5FJKYUOUKijj5gIDy/sOIAZ7BxDWb0co1VzZokdN7tvtLnQtiWfD1Gw==",
+          "dev": true
         },
         "broccoli-output-wrapper": {
           "version": "3.2.3",
           "resolved": "https://registry.npmjs.org/broccoli-output-wrapper/-/broccoli-output-wrapper-3.2.3.tgz",
           "integrity": "sha512-vzbm4j59Wr5vr/O50LD43Np1jbLBWJ/vhppzL/UXWf39xac9grJtrlx9SSy+pDRNT2LGBHNIGPOhdqwp94q2Pg==",
+          "dev": true,
           "requires": {
             "fs-extra": "^8.1.0",
             "heimdalljs-logger": "^0.1.10",
@@ -11981,6 +13470,7 @@
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/broccoli-persistent-filter/-/broccoli-persistent-filter-3.1.0.tgz",
           "integrity": "sha512-yHHPv7M04qb9ajo3QkbGWetpshekVYG8sSjNdgAPQQ3spiRvS6RthYBddni5iw9b2DidSCpe/YPGRnp7LL4OIQ==",
+          "dev": true,
           "requires": {
             "async-disk-cache": "^2.0.0",
             "async-promise-queue": "^1.0.3",
@@ -12000,6 +13490,7 @@
           "version": "4.0.3",
           "resolved": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-4.0.3.tgz",
           "integrity": "sha512-CtAIEYq5K+4yQv8c/BHymOteuyjDAJfvy/asu4LudIWcMSS7dTn3yGI5gNBkwHG+qlRangYkHJNVAcDZMQbSVQ==",
+          "dev": true,
           "requires": {
             "broccoli-node-api": "^1.6.0",
             "broccoli-output-wrapper": "^3.2.1",
@@ -12014,6 +13505,7 @@
           "version": "2.3.1",
           "resolved": "https://registry.npmjs.org/editions/-/editions-2.3.1.tgz",
           "integrity": "sha512-ptGvkwTvGdGfC0hfhKg0MT+TRLRKGtUiWGBInxOm5pz7ssADezahjCUaYuZ8Dr+C05FW0AECIIPt4WBxVINEhA==",
+          "dev": true,
           "requires": {
             "errlop": "^2.0.0",
             "semver": "^6.3.0"
@@ -12022,7 +13514,8 @@
             "semver": {
               "version": "6.3.0",
               "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-              "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+              "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+              "dev": true
             }
           }
         },
@@ -12030,6 +13523,7 @@
           "version": "8.1.0",
           "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
           "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+          "dev": true,
           "requires": {
             "graceful-fs": "^4.2.0",
             "jsonfile": "^4.0.0",
@@ -12040,6 +13534,7 @@
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/fs-tree-diff/-/fs-tree-diff-2.0.1.tgz",
           "integrity": "sha512-x+CfAZ/lJHQqwlD64pYM5QxWjzWhSjroaVsr8PW831zOApL55qPibed0c+xebaLWVr2BnHFoHdrwOv8pzt8R5A==",
+          "dev": true,
           "requires": {
             "@types/symlink-or-copy": "^1.2.0",
             "heimdalljs-logger": "^0.1.7",
@@ -12052,6 +13547,7 @@
           "version": "2.6.0",
           "resolved": "https://registry.npmjs.org/istextorbinary/-/istextorbinary-2.6.0.tgz",
           "integrity": "sha512-+XRlFseT8B3L9KyjxxLjfXSLMuErKDsd8DBNrsaxoViABMEZlOSCstwmw0qpoFX3+U6yWU1yhLudAe6/lETGGA==",
+          "dev": true,
           "requires": {
             "binaryextensions": "^2.1.2",
             "editions": "^2.2.0",
@@ -12062,6 +13558,7 @@
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/matcher-collection/-/matcher-collection-2.0.1.tgz",
           "integrity": "sha512-daE62nS2ZQsDg9raM0IlZzLmI2u+7ZapXBwdoeBUKAYERPDDIc0qNqA8E0Rp2D+gspKR7BgIFP52GeujaGXWeQ==",
+          "dev": true,
           "requires": {
             "@types/minimatch": "^3.0.3",
             "minimatch": "^3.0.2"
@@ -12070,17 +13567,20 @@
         "semver": {
           "version": "7.3.2",
           "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
-          "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ=="
+          "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
+          "dev": true
         },
         "strip-bom": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
-          "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w=="
+          "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
+          "dev": true
         },
         "sync-disk-cache": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/sync-disk-cache/-/sync-disk-cache-2.1.0.tgz",
           "integrity": "sha512-vngT2JmkSapgq0z7uIoYtB9kWOOzMihAAYq/D3Pjm/ODOGMgS4r++B+OZ09U4hWR6EaOdy9eqQ7/8ygbH3wehA==",
+          "dev": true,
           "requires": {
             "debug": "^4.1.1",
             "heimdalljs": "^0.2.6",
@@ -12093,6 +13593,7 @@
           "version": "2.2.0",
           "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-2.2.0.tgz",
           "integrity": "sha512-IC8sL7aB4/ZgFcGI2T1LczZeFWZ06b3zoHH7jBPyHxOtIIz1jppWHjjEXkOFvFojBVAK9pV7g47xOZ4LW3QLfg==",
+          "dev": true,
           "requires": {
             "@types/minimatch": "^3.0.3",
             "ensure-posix-path": "^1.1.0",
@@ -12188,6 +13689,44 @@
         "process-relative-require": "^1.0.0"
       },
       "dependencies": {
+        "broccoli-funnel": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-2.0.2.tgz",
+          "integrity": "sha512-/vDTqtv7ipjEZQOVqO4vGDVAOZyuYzQ/EgGoyewfOgh1M7IQAToBKZI0oAQPgMBeFPPlIbfMuAngk+ohPBuaHQ==",
+          "dev": true,
+          "requires": {
+            "array-equal": "^1.0.0",
+            "blank-object": "^1.0.1",
+            "broccoli-plugin": "^1.3.0",
+            "debug": "^2.2.0",
+            "fast-ordered-set": "^1.0.0",
+            "fs-tree-diff": "^0.5.3",
+            "heimdalljs": "^0.2.0",
+            "minimatch": "^3.0.0",
+            "mkdirp": "^0.5.0",
+            "path-posix": "^1.0.0",
+            "rimraf": "^2.4.3",
+            "symlink-or-copy": "^1.0.0",
+            "walk-sync": "^0.3.1"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "2.6.9",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+              "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+              "dev": true,
+              "requires": {
+                "ms": "2.0.0"
+              }
+            },
+            "ms": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+              "dev": true
+            }
+          }
+        },
         "debug": {
           "version": "3.2.6",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
@@ -12195,6 +13734,15 @@
           "dev": true,
           "requires": {
             "ms": "^2.1.1"
+          }
+        },
+        "rimraf": {
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
           }
         }
       }
@@ -12211,6 +13759,36 @@
         "ember-cli-version-checker": "^2.1.0"
       },
       "dependencies": {
+        "broccoli-funnel": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-2.0.2.tgz",
+          "integrity": "sha512-/vDTqtv7ipjEZQOVqO4vGDVAOZyuYzQ/EgGoyewfOgh1M7IQAToBKZI0oAQPgMBeFPPlIbfMuAngk+ohPBuaHQ==",
+          "dev": true,
+          "requires": {
+            "array-equal": "^1.0.0",
+            "blank-object": "^1.0.1",
+            "broccoli-plugin": "^1.3.0",
+            "debug": "^2.2.0",
+            "fast-ordered-set": "^1.0.0",
+            "fs-tree-diff": "^0.5.3",
+            "heimdalljs": "^0.2.0",
+            "minimatch": "^3.0.0",
+            "mkdirp": "^0.5.0",
+            "path-posix": "^1.0.0",
+            "rimraf": "^2.4.3",
+            "symlink-or-copy": "^1.0.0",
+            "walk-sync": "^0.3.1"
+          }
+        },
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
         "ember-cli-version-checker": {
           "version": "2.2.0",
           "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-2.2.0.tgz",
@@ -12219,6 +13797,21 @@
           "requires": {
             "resolve": "^1.3.3",
             "semver": "^5.3.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        },
+        "rimraf": {
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
           }
         }
       }
@@ -12256,6 +13849,15 @@
             "semver": "^5.3.0"
           }
         },
+        "babel-plugin-ember-modules-api-polyfill": {
+          "version": "2.13.4",
+          "resolved": "https://registry.npmjs.org/babel-plugin-ember-modules-api-polyfill/-/babel-plugin-ember-modules-api-polyfill-2.13.4.tgz",
+          "integrity": "sha512-uxQPkEQAzCYdwhZk16O9m1R4xtCRNy4oEUTBrccOPfzlIahRZJic/JeP/ZEL0BC6Mfq6r55eOg6gMF/zdFoCvA==",
+          "dev": true,
+          "requires": {
+            "ember-rfc176-data": "^0.3.13"
+          }
+        },
         "broccoli-babel-transpiler": {
           "version": "6.5.1",
           "resolved": "https://registry.npmjs.org/broccoli-babel-transpiler/-/broccoli-babel-transpiler-6.5.1.tgz",
@@ -12272,6 +13874,29 @@
             "json-stable-stringify": "^1.0.0",
             "rsvp": "^4.8.2",
             "workerpool": "^2.3.0"
+          },
+          "dependencies": {
+            "broccoli-funnel": {
+              "version": "2.0.2",
+              "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-2.0.2.tgz",
+              "integrity": "sha512-/vDTqtv7ipjEZQOVqO4vGDVAOZyuYzQ/EgGoyewfOgh1M7IQAToBKZI0oAQPgMBeFPPlIbfMuAngk+ohPBuaHQ==",
+              "dev": true,
+              "requires": {
+                "array-equal": "^1.0.0",
+                "blank-object": "^1.0.1",
+                "broccoli-plugin": "^1.3.0",
+                "debug": "^2.2.0",
+                "fast-ordered-set": "^1.0.0",
+                "fs-tree-diff": "^0.5.3",
+                "heimdalljs": "^0.2.0",
+                "minimatch": "^3.0.0",
+                "mkdirp": "^0.5.0",
+                "path-posix": "^1.0.0",
+                "rimraf": "^2.4.3",
+                "symlink-or-copy": "^1.0.0",
+                "walk-sync": "^0.3.1"
+              }
+            }
           }
         },
         "broccoli-merge-trees": {
@@ -12313,6 +13938,15 @@
             }
           }
         },
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
         "ember-cli-babel": {
           "version": "6.18.0",
           "resolved": "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-6.18.0.tgz",
@@ -12332,6 +13966,29 @@
             "clone": "^2.0.0",
             "ember-cli-version-checker": "^2.1.2",
             "semver": "^5.5.0"
+          },
+          "dependencies": {
+            "broccoli-funnel": {
+              "version": "2.0.2",
+              "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-2.0.2.tgz",
+              "integrity": "sha512-/vDTqtv7ipjEZQOVqO4vGDVAOZyuYzQ/EgGoyewfOgh1M7IQAToBKZI0oAQPgMBeFPPlIbfMuAngk+ohPBuaHQ==",
+              "dev": true,
+              "requires": {
+                "array-equal": "^1.0.0",
+                "blank-object": "^1.0.1",
+                "broccoli-plugin": "^1.3.0",
+                "debug": "^2.2.0",
+                "fast-ordered-set": "^1.0.0",
+                "fs-tree-diff": "^0.5.3",
+                "heimdalljs": "^0.2.0",
+                "minimatch": "^3.0.0",
+                "mkdirp": "^0.5.0",
+                "path-posix": "^1.0.0",
+                "rimraf": "^2.4.3",
+                "symlink-or-copy": "^1.0.0",
+                "walk-sync": "^0.3.1"
+              }
+            }
           }
         },
         "ember-cli-version-checker": {
@@ -12357,6 +14014,12 @@
             "rimraf": "^2.4.3",
             "symlink-or-copy": "^1.0.0"
           }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
         },
         "rimraf": {
           "version": "2.7.1",
@@ -12946,9 +14609,9 @@
       }
     },
     "ember-cli-version-checker": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-4.1.0.tgz",
-      "integrity": "sha512-yLf2YqotTSsjiXwx9Dt6H7AU0QcldFn5SLk/pG3Zqb0aHNeanBOPlx4/Ysa46ILGWYIh0fDH34AEVRueXTrQBQ==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-4.1.1.tgz",
+      "integrity": "sha512-bzEWsTMXUGEJfxcAGWPe6kI7oHEGD3jaxUWDYPTqzqGhNkgPwXTBgoWs9zG1RaSMaOPFnloWuxRcoHi4TrYS3Q==",
       "requires": {
         "resolve-package-path": "^2.0.0",
         "semver": "^6.3.0",
@@ -13027,6 +14690,14 @@
             "semver": "^5.3.0"
           }
         },
+        "babel-plugin-ember-modules-api-polyfill": {
+          "version": "2.13.4",
+          "resolved": "https://registry.npmjs.org/babel-plugin-ember-modules-api-polyfill/-/babel-plugin-ember-modules-api-polyfill-2.13.4.tgz",
+          "integrity": "sha512-uxQPkEQAzCYdwhZk16O9m1R4xtCRNy4oEUTBrccOPfzlIahRZJic/JeP/ZEL0BC6Mfq6r55eOg6gMF/zdFoCvA==",
+          "requires": {
+            "ember-rfc176-data": "^0.3.13"
+          }
+        },
         "broccoli-babel-transpiler": {
           "version": "6.5.1",
           "resolved": "https://registry.npmjs.org/broccoli-babel-transpiler/-/broccoli-babel-transpiler-6.5.1.tgz",
@@ -13042,6 +14713,28 @@
             "json-stable-stringify": "^1.0.0",
             "rsvp": "^4.8.2",
             "workerpool": "^2.3.0"
+          },
+          "dependencies": {
+            "broccoli-funnel": {
+              "version": "2.0.2",
+              "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-2.0.2.tgz",
+              "integrity": "sha512-/vDTqtv7ipjEZQOVqO4vGDVAOZyuYzQ/EgGoyewfOgh1M7IQAToBKZI0oAQPgMBeFPPlIbfMuAngk+ohPBuaHQ==",
+              "requires": {
+                "array-equal": "^1.0.0",
+                "blank-object": "^1.0.1",
+                "broccoli-plugin": "^1.3.0",
+                "debug": "^2.2.0",
+                "fast-ordered-set": "^1.0.0",
+                "fs-tree-diff": "^0.5.3",
+                "heimdalljs": "^0.2.0",
+                "minimatch": "^3.0.0",
+                "mkdirp": "^0.5.0",
+                "path-posix": "^1.0.0",
+                "rimraf": "^2.4.3",
+                "symlink-or-copy": "^1.0.0",
+                "walk-sync": "^0.3.1"
+              }
+            }
           }
         },
         "broccoli-merge-trees": {
@@ -13080,6 +14773,14 @@
             }
           }
         },
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
         "ember-cli-babel": {
           "version": "6.18.0",
           "resolved": "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-6.18.0.tgz",
@@ -13098,6 +14799,28 @@
             "clone": "^2.0.0",
             "ember-cli-version-checker": "^2.1.2",
             "semver": "^5.5.0"
+          },
+          "dependencies": {
+            "broccoli-funnel": {
+              "version": "2.0.2",
+              "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-2.0.2.tgz",
+              "integrity": "sha512-/vDTqtv7ipjEZQOVqO4vGDVAOZyuYzQ/EgGoyewfOgh1M7IQAToBKZI0oAQPgMBeFPPlIbfMuAngk+ohPBuaHQ==",
+              "requires": {
+                "array-equal": "^1.0.0",
+                "blank-object": "^1.0.1",
+                "broccoli-plugin": "^1.3.0",
+                "debug": "^2.2.0",
+                "fast-ordered-set": "^1.0.0",
+                "fs-tree-diff": "^0.5.3",
+                "heimdalljs": "^0.2.0",
+                "minimatch": "^3.0.0",
+                "mkdirp": "^0.5.0",
+                "path-posix": "^1.0.0",
+                "rimraf": "^2.4.3",
+                "symlink-or-copy": "^1.0.0",
+                "walk-sync": "^0.3.1"
+              }
+            }
           }
         },
         "ember-cli-version-checker": {
@@ -13108,6 +14831,11 @@
             "resolve": "^1.3.3",
             "semver": "^5.3.0"
           }
+        },
+        "ember-rfc176-data": {
+          "version": "0.3.15",
+          "resolved": "https://registry.npmjs.org/ember-rfc176-data/-/ember-rfc176-data-0.3.15.tgz",
+          "integrity": "sha512-GPKa7zRDBblRy0orxTXt5yrpp/Pf5CkuRFSIR8qMFDww0CqCKjCRwdZnWYzCM4kAEfZnXRIDDefe1tBaFw7v7w=="
         },
         "merge-trees": {
           "version": "1.0.1",
@@ -13121,6 +14849,11 @@
             "rimraf": "^2.4.3",
             "symlink-or-copy": "^1.0.0"
           }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         },
         "rimraf": {
           "version": "2.7.1",
@@ -13174,6 +14907,15 @@
             "semver": "^5.3.0"
           }
         },
+        "babel-plugin-ember-modules-api-polyfill": {
+          "version": "2.13.4",
+          "resolved": "https://registry.npmjs.org/babel-plugin-ember-modules-api-polyfill/-/babel-plugin-ember-modules-api-polyfill-2.13.4.tgz",
+          "integrity": "sha512-uxQPkEQAzCYdwhZk16O9m1R4xtCRNy4oEUTBrccOPfzlIahRZJic/JeP/ZEL0BC6Mfq6r55eOg6gMF/zdFoCvA==",
+          "dev": true,
+          "requires": {
+            "ember-rfc176-data": "^0.3.13"
+          }
+        },
         "broccoli-babel-transpiler": {
           "version": "6.5.1",
           "resolved": "https://registry.npmjs.org/broccoli-babel-transpiler/-/broccoli-babel-transpiler-6.5.1.tgz",
@@ -13190,6 +14932,29 @@
             "json-stable-stringify": "^1.0.0",
             "rsvp": "^4.8.2",
             "workerpool": "^2.3.0"
+          },
+          "dependencies": {
+            "broccoli-funnel": {
+              "version": "2.0.2",
+              "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-2.0.2.tgz",
+              "integrity": "sha512-/vDTqtv7ipjEZQOVqO4vGDVAOZyuYzQ/EgGoyewfOgh1M7IQAToBKZI0oAQPgMBeFPPlIbfMuAngk+ohPBuaHQ==",
+              "dev": true,
+              "requires": {
+                "array-equal": "^1.0.0",
+                "blank-object": "^1.0.1",
+                "broccoli-plugin": "^1.3.0",
+                "debug": "^2.2.0",
+                "fast-ordered-set": "^1.0.0",
+                "fs-tree-diff": "^0.5.3",
+                "heimdalljs": "^0.2.0",
+                "minimatch": "^3.0.0",
+                "mkdirp": "^0.5.0",
+                "path-posix": "^1.0.0",
+                "rimraf": "^2.4.3",
+                "symlink-or-copy": "^1.0.0",
+                "walk-sync": "^0.3.1"
+              }
+            }
           }
         },
         "broccoli-merge-trees": {
@@ -13231,6 +14996,15 @@
             }
           }
         },
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
         "ember-cli-babel": {
           "version": "6.18.0",
           "resolved": "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-6.18.0.tgz",
@@ -13250,6 +15024,29 @@
             "clone": "^2.0.0",
             "ember-cli-version-checker": "^2.1.2",
             "semver": "^5.5.0"
+          },
+          "dependencies": {
+            "broccoli-funnel": {
+              "version": "2.0.2",
+              "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-2.0.2.tgz",
+              "integrity": "sha512-/vDTqtv7ipjEZQOVqO4vGDVAOZyuYzQ/EgGoyewfOgh1M7IQAToBKZI0oAQPgMBeFPPlIbfMuAngk+ohPBuaHQ==",
+              "dev": true,
+              "requires": {
+                "array-equal": "^1.0.0",
+                "blank-object": "^1.0.1",
+                "broccoli-plugin": "^1.3.0",
+                "debug": "^2.2.0",
+                "fast-ordered-set": "^1.0.0",
+                "fs-tree-diff": "^0.5.3",
+                "heimdalljs": "^0.2.0",
+                "minimatch": "^3.0.0",
+                "mkdirp": "^0.5.0",
+                "path-posix": "^1.0.0",
+                "rimraf": "^2.4.3",
+                "symlink-or-copy": "^1.0.0",
+                "walk-sync": "^0.3.1"
+              }
+            }
           }
         },
         "ember-cli-version-checker": {
@@ -13276,6 +15073,12 @@
             "symlink-or-copy": "^1.0.0"
           }
         },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        },
         "rimraf": {
           "version": "2.7.1",
           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
@@ -13292,1102 +15095,6 @@
           "dev": true,
           "requires": {
             "object-assign": "4.1.1"
-          }
-        }
-      }
-    },
-    "ember-in-element-polyfill": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/ember-in-element-polyfill/-/ember-in-element-polyfill-1.0.0.tgz",
-      "integrity": "sha512-0eSfWWgkOMvj7lcjo20VX8uX4HYxSOxm6MY3bAzqW5RpnHcpcrRf6o4y80xLGh5pp9z8FobiUfFwubphACP8mQ==",
-      "requires": {
-        "debug": "^4.1.1",
-        "ember-cli-babel": "^7.19.0",
-        "ember-cli-htmlbars": "^4.3.1",
-        "ember-cli-version-checker": "^5.0.2"
-      },
-      "dependencies": {
-        "@babel/code-frame": {
-          "version": "7.10.1",
-          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.1.tgz",
-          "integrity": "sha512-IGhtTmpjGbYzcEDOw7DcQtbQSXcG9ftmAXtWTu9V936vDye4xjjekktFAtgZsWpzTj/X01jocB46mTywm/4SZw==",
-          "requires": {
-            "@babel/highlight": "^7.10.1"
-          }
-        },
-        "@babel/compat-data": {
-          "version": "7.10.1",
-          "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.10.1.tgz",
-          "integrity": "sha512-CHvCj7So7iCkGKPRFUfryXIkU2gSBw7VSZFYLsqVhrS47269VK2Hfi9S/YcublPMW8k1u2bQBlbDruoQEm4fgw==",
-          "requires": {
-            "browserslist": "^4.12.0",
-            "invariant": "^2.2.4",
-            "semver": "^5.5.0"
-          }
-        },
-        "@babel/core": {
-          "version": "7.10.2",
-          "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.10.2.tgz",
-          "integrity": "sha512-KQmV9yguEjQsXqyOUGKjS4+3K8/DlOCE2pZcq4augdQmtTy5iv5EHtmMSJ7V4c1BIPjuwtZYqYLCq9Ga+hGBRQ==",
-          "requires": {
-            "@babel/code-frame": "^7.10.1",
-            "@babel/generator": "^7.10.2",
-            "@babel/helper-module-transforms": "^7.10.1",
-            "@babel/helpers": "^7.10.1",
-            "@babel/parser": "^7.10.2",
-            "@babel/template": "^7.10.1",
-            "@babel/traverse": "^7.10.1",
-            "@babel/types": "^7.10.2",
-            "convert-source-map": "^1.7.0",
-            "debug": "^4.1.0",
-            "gensync": "^1.0.0-beta.1",
-            "json5": "^2.1.2",
-            "lodash": "^4.17.13",
-            "resolve": "^1.3.2",
-            "semver": "^5.4.1",
-            "source-map": "^0.5.0"
-          }
-        },
-        "@babel/generator": {
-          "version": "7.10.2",
-          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.10.2.tgz",
-          "integrity": "sha512-AxfBNHNu99DTMvlUPlt1h2+Hn7knPpH5ayJ8OqDWSeLld+Fi2AYBTC/IejWDM9Edcii4UzZRCsbUt0WlSDsDsA==",
-          "requires": {
-            "@babel/types": "^7.10.2",
-            "jsesc": "^2.5.1",
-            "lodash": "^4.17.13",
-            "source-map": "^0.5.0"
-          }
-        },
-        "@babel/helper-annotate-as-pure": {
-          "version": "7.10.1",
-          "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.10.1.tgz",
-          "integrity": "sha512-ewp3rvJEwLaHgyWGe4wQssC2vjks3E80WiUe2BpMb0KhreTjMROCbxXcEovTrbeGVdQct5VjQfrv9EgC+xMzCw==",
-          "requires": {
-            "@babel/types": "^7.10.1"
-          }
-        },
-        "@babel/helper-builder-binary-assignment-operator-visitor": {
-          "version": "7.10.1",
-          "resolved": "https://registry.npmjs.org/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.10.1.tgz",
-          "integrity": "sha512-cQpVq48EkYxUU0xozpGCLla3wlkdRRqLWu1ksFMXA9CM5KQmyyRpSEsYXbao7JUkOw/tAaYKCaYyZq6HOFYtyw==",
-          "requires": {
-            "@babel/helper-explode-assignable-expression": "^7.10.1",
-            "@babel/types": "^7.10.1"
-          }
-        },
-        "@babel/helper-compilation-targets": {
-          "version": "7.10.2",
-          "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.10.2.tgz",
-          "integrity": "sha512-hYgOhF4To2UTB4LTaZepN/4Pl9LD4gfbJx8A34mqoluT8TLbof1mhUlYuNWTEebONa8+UlCC4X0TEXu7AOUyGA==",
-          "requires": {
-            "@babel/compat-data": "^7.10.1",
-            "browserslist": "^4.12.0",
-            "invariant": "^2.2.4",
-            "levenary": "^1.1.1",
-            "semver": "^5.5.0"
-          }
-        },
-        "@babel/helper-create-class-features-plugin": {
-          "version": "7.10.2",
-          "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.10.2.tgz",
-          "integrity": "sha512-5C/QhkGFh1vqcziq1vAL6SI9ymzUp8BCYjFpvYVhWP4DlATIb3u5q3iUd35mvlyGs8fO7hckkW7i0tmH+5+bvQ==",
-          "requires": {
-            "@babel/helper-function-name": "^7.10.1",
-            "@babel/helper-member-expression-to-functions": "^7.10.1",
-            "@babel/helper-optimise-call-expression": "^7.10.1",
-            "@babel/helper-plugin-utils": "^7.10.1",
-            "@babel/helper-replace-supers": "^7.10.1",
-            "@babel/helper-split-export-declaration": "^7.10.1"
-          }
-        },
-        "@babel/helper-create-regexp-features-plugin": {
-          "version": "7.10.1",
-          "resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.10.1.tgz",
-          "integrity": "sha512-Rx4rHS0pVuJn5pJOqaqcZR4XSgeF9G/pO/79t+4r7380tXFJdzImFnxMU19f83wjSrmKHq6myrM10pFHTGzkUA==",
-          "requires": {
-            "@babel/helper-annotate-as-pure": "^7.10.1",
-            "@babel/helper-regex": "^7.10.1",
-            "regexpu-core": "^4.7.0"
-          }
-        },
-        "@babel/helper-define-map": {
-          "version": "7.10.1",
-          "resolved": "https://registry.npmjs.org/@babel/helper-define-map/-/helper-define-map-7.10.1.tgz",
-          "integrity": "sha512-+5odWpX+OnvkD0Zmq7panrMuAGQBu6aPUgvMzuMGo4R+jUOvealEj2hiqI6WhxgKrTpFoFj0+VdsuA8KDxHBDg==",
-          "requires": {
-            "@babel/helper-function-name": "^7.10.1",
-            "@babel/types": "^7.10.1",
-            "lodash": "^4.17.13"
-          }
-        },
-        "@babel/helper-explode-assignable-expression": {
-          "version": "7.10.1",
-          "resolved": "https://registry.npmjs.org/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.10.1.tgz",
-          "integrity": "sha512-vcUJ3cDjLjvkKzt6rHrl767FeE7pMEYfPanq5L16GRtrXIoznc0HykNW2aEYkcnP76P0isoqJ34dDMFZwzEpJg==",
-          "requires": {
-            "@babel/traverse": "^7.10.1",
-            "@babel/types": "^7.10.1"
-          }
-        },
-        "@babel/helper-function-name": {
-          "version": "7.10.1",
-          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.10.1.tgz",
-          "integrity": "sha512-fcpumwhs3YyZ/ttd5Rz0xn0TpIwVkN7X0V38B9TWNfVF42KEkhkAAuPCQ3oXmtTRtiPJrmZ0TrfS0GKF0eMaRQ==",
-          "requires": {
-            "@babel/helper-get-function-arity": "^7.10.1",
-            "@babel/template": "^7.10.1",
-            "@babel/types": "^7.10.1"
-          }
-        },
-        "@babel/helper-get-function-arity": {
-          "version": "7.10.1",
-          "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.10.1.tgz",
-          "integrity": "sha512-F5qdXkYGOQUb0hpRaPoetF9AnsXknKjWMZ+wmsIRsp5ge5sFh4c3h1eH2pRTTuy9KKAA2+TTYomGXAtEL2fQEw==",
-          "requires": {
-            "@babel/types": "^7.10.1"
-          }
-        },
-        "@babel/helper-hoist-variables": {
-          "version": "7.10.1",
-          "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.10.1.tgz",
-          "integrity": "sha512-vLm5srkU8rI6X3+aQ1rQJyfjvCBLXP8cAGeuw04zeAM2ItKb1e7pmVmLyHb4sDaAYnLL13RHOZPLEtcGZ5xvjg==",
-          "requires": {
-            "@babel/types": "^7.10.1"
-          }
-        },
-        "@babel/helper-member-expression-to-functions": {
-          "version": "7.10.1",
-          "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.10.1.tgz",
-          "integrity": "sha512-u7XLXeM2n50gb6PWJ9hoO5oO7JFPaZtrh35t8RqKLT1jFKj9IWeD1zrcrYp1q1qiZTdEarfDWfTIP8nGsu0h5g==",
-          "requires": {
-            "@babel/types": "^7.10.1"
-          }
-        },
-        "@babel/helper-module-imports": {
-          "version": "7.10.1",
-          "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.10.1.tgz",
-          "integrity": "sha512-SFxgwYmZ3HZPyZwJRiVNLRHWuW2OgE5k2nrVs6D9Iv4PPnXVffuEHy83Sfx/l4SqF+5kyJXjAyUmrG7tNm+qVg==",
-          "requires": {
-            "@babel/types": "^7.10.1"
-          }
-        },
-        "@babel/helper-module-transforms": {
-          "version": "7.10.1",
-          "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.10.1.tgz",
-          "integrity": "sha512-RLHRCAzyJe7Q7sF4oy2cB+kRnU4wDZY/H2xJFGof+M+SJEGhZsb+GFj5j1AD8NiSaVBJ+Pf0/WObiXu/zxWpFg==",
-          "requires": {
-            "@babel/helper-module-imports": "^7.10.1",
-            "@babel/helper-replace-supers": "^7.10.1",
-            "@babel/helper-simple-access": "^7.10.1",
-            "@babel/helper-split-export-declaration": "^7.10.1",
-            "@babel/template": "^7.10.1",
-            "@babel/types": "^7.10.1",
-            "lodash": "^4.17.13"
-          }
-        },
-        "@babel/helper-optimise-call-expression": {
-          "version": "7.10.1",
-          "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.10.1.tgz",
-          "integrity": "sha512-a0DjNS1prnBsoKx83dP2falChcs7p3i8VMzdrSbfLhuQra/2ENC4sbri34dz/rWmDADsmF1q5GbfaXydh0Jbjg==",
-          "requires": {
-            "@babel/types": "^7.10.1"
-          }
-        },
-        "@babel/helper-plugin-utils": {
-          "version": "7.10.1",
-          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.1.tgz",
-          "integrity": "sha512-fvoGeXt0bJc7VMWZGCAEBEMo/HAjW2mP8apF5eXK0wSqwLAVHAISCWRoLMBMUs2kqeaG77jltVqu4Hn8Egl3nA=="
-        },
-        "@babel/helper-regex": {
-          "version": "7.10.1",
-          "resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.10.1.tgz",
-          "integrity": "sha512-7isHr19RsIJWWLLFn21ubFt223PjQyg1HY7CZEMRr820HttHPpVvrsIN3bUOo44DEfFV4kBXO7Abbn9KTUZV7g==",
-          "requires": {
-            "lodash": "^4.17.13"
-          }
-        },
-        "@babel/helper-remap-async-to-generator": {
-          "version": "7.10.1",
-          "resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.10.1.tgz",
-          "integrity": "sha512-RfX1P8HqsfgmJ6CwaXGKMAqbYdlleqglvVtht0HGPMSsy2V6MqLlOJVF/0Qyb/m2ZCi2z3q3+s6Pv7R/dQuZ6A==",
-          "requires": {
-            "@babel/helper-annotate-as-pure": "^7.10.1",
-            "@babel/helper-wrap-function": "^7.10.1",
-            "@babel/template": "^7.10.1",
-            "@babel/traverse": "^7.10.1",
-            "@babel/types": "^7.10.1"
-          }
-        },
-        "@babel/helper-replace-supers": {
-          "version": "7.10.1",
-          "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.10.1.tgz",
-          "integrity": "sha512-SOwJzEfpuQwInzzQJGjGaiG578UYmyi2Xw668klPWV5n07B73S0a9btjLk/52Mlcxa+5AdIYqws1KyXRfMoB7A==",
-          "requires": {
-            "@babel/helper-member-expression-to-functions": "^7.10.1",
-            "@babel/helper-optimise-call-expression": "^7.10.1",
-            "@babel/traverse": "^7.10.1",
-            "@babel/types": "^7.10.1"
-          }
-        },
-        "@babel/helper-simple-access": {
-          "version": "7.10.1",
-          "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.10.1.tgz",
-          "integrity": "sha512-VSWpWzRzn9VtgMJBIWTZ+GP107kZdQ4YplJlCmIrjoLVSi/0upixezHCDG8kpPVTBJpKfxTH01wDhh+jS2zKbw==",
-          "requires": {
-            "@babel/template": "^7.10.1",
-            "@babel/types": "^7.10.1"
-          }
-        },
-        "@babel/helper-split-export-declaration": {
-          "version": "7.10.1",
-          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.10.1.tgz",
-          "integrity": "sha512-UQ1LVBPrYdbchNhLwj6fetj46BcFwfS4NllJo/1aJsT+1dLTEnXJL0qHqtY7gPzF8S2fXBJamf1biAXV3X077g==",
-          "requires": {
-            "@babel/types": "^7.10.1"
-          }
-        },
-        "@babel/helper-wrap-function": {
-          "version": "7.10.1",
-          "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.10.1.tgz",
-          "integrity": "sha512-C0MzRGteVDn+H32/ZgbAv5r56f2o1fZSA/rj/TYo8JEJNHg+9BdSmKBUND0shxWRztWhjlT2cvHYuynpPsVJwQ==",
-          "requires": {
-            "@babel/helper-function-name": "^7.10.1",
-            "@babel/template": "^7.10.1",
-            "@babel/traverse": "^7.10.1",
-            "@babel/types": "^7.10.1"
-          }
-        },
-        "@babel/helpers": {
-          "version": "7.10.1",
-          "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.10.1.tgz",
-          "integrity": "sha512-muQNHF+IdU6wGgkaJyhhEmI54MOZBKsFfsXFhboz1ybwJ1Kl7IHlbm2a++4jwrmY5UYsgitt5lfqo1wMFcHmyw==",
-          "requires": {
-            "@babel/template": "^7.10.1",
-            "@babel/traverse": "^7.10.1",
-            "@babel/types": "^7.10.1"
-          }
-        },
-        "@babel/highlight": {
-          "version": "7.10.1",
-          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.1.tgz",
-          "integrity": "sha512-8rMof+gVP8mxYZApLF/JgNDAkdKa+aJt3ZYxF8z6+j/hpeXL7iMsKCPHa2jNMHu/qqBwzQF4OHNoYi8dMA/rYg==",
-          "requires": {
-            "@babel/helper-validator-identifier": "^7.10.1",
-            "chalk": "^2.0.0",
-            "js-tokens": "^4.0.0"
-          }
-        },
-        "@babel/parser": {
-          "version": "7.10.2",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.10.2.tgz",
-          "integrity": "sha512-PApSXlNMJyB4JiGVhCOlzKIif+TKFTvu0aQAhnTvfP/z3vVSN6ZypH5bfUNwFXXjRQtUEBNFd2PtmCmG2Py3qQ=="
-        },
-        "@babel/plugin-proposal-async-generator-functions": {
-          "version": "7.10.1",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.10.1.tgz",
-          "integrity": "sha512-vzZE12ZTdB336POZjmpblWfNNRpMSua45EYnRigE2XsZxcXcIyly2ixnTJasJE4Zq3U7t2d8rRF7XRUuzHxbOw==",
-          "requires": {
-            "@babel/helper-plugin-utils": "^7.10.1",
-            "@babel/helper-remap-async-to-generator": "^7.10.1",
-            "@babel/plugin-syntax-async-generators": "^7.8.0"
-          }
-        },
-        "@babel/plugin-proposal-dynamic-import": {
-          "version": "7.10.1",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-dynamic-import/-/plugin-proposal-dynamic-import-7.10.1.tgz",
-          "integrity": "sha512-Cpc2yUVHTEGPlmiQzXj026kqwjEQAD9I4ZC16uzdbgWgitg/UHKHLffKNCQZ5+y8jpIZPJcKcwsr2HwPh+w3XA==",
-          "requires": {
-            "@babel/helper-plugin-utils": "^7.10.1",
-            "@babel/plugin-syntax-dynamic-import": "^7.8.0"
-          }
-        },
-        "@babel/plugin-proposal-json-strings": {
-          "version": "7.10.1",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.10.1.tgz",
-          "integrity": "sha512-m8r5BmV+ZLpWPtMY2mOKN7wre6HIO4gfIiV+eOmsnZABNenrt/kzYBwrh+KOfgumSWpnlGs5F70J8afYMSJMBg==",
-          "requires": {
-            "@babel/helper-plugin-utils": "^7.10.1",
-            "@babel/plugin-syntax-json-strings": "^7.8.0"
-          }
-        },
-        "@babel/plugin-proposal-nullish-coalescing-operator": {
-          "version": "7.10.1",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-nullish-coalescing-operator/-/plugin-proposal-nullish-coalescing-operator-7.10.1.tgz",
-          "integrity": "sha512-56cI/uHYgL2C8HVuHOuvVowihhX0sxb3nnfVRzUeVHTWmRHTZrKuAh/OBIMggGU/S1g/1D2CRCXqP+3u7vX7iA==",
-          "requires": {
-            "@babel/helper-plugin-utils": "^7.10.1",
-            "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.0"
-          }
-        },
-        "@babel/plugin-proposal-object-rest-spread": {
-          "version": "7.10.1",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.10.1.tgz",
-          "integrity": "sha512-Z+Qri55KiQkHh7Fc4BW6o+QBuTagbOp9txE+4U1i79u9oWlf2npkiDx+Rf3iK3lbcHBuNy9UOkwuR5wOMH3LIQ==",
-          "requires": {
-            "@babel/helper-plugin-utils": "^7.10.1",
-            "@babel/plugin-syntax-object-rest-spread": "^7.8.0",
-            "@babel/plugin-transform-parameters": "^7.10.1"
-          }
-        },
-        "@babel/plugin-proposal-optional-catch-binding": {
-          "version": "7.10.1",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.10.1.tgz",
-          "integrity": "sha512-VqExgeE62YBqI3ogkGoOJp1R6u12DFZjqwJhqtKc2o5m1YTUuUWnos7bZQFBhwkxIFpWYJ7uB75U7VAPPiKETA==",
-          "requires": {
-            "@babel/helper-plugin-utils": "^7.10.1",
-            "@babel/plugin-syntax-optional-catch-binding": "^7.8.0"
-          }
-        },
-        "@babel/plugin-proposal-optional-chaining": {
-          "version": "7.10.1",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.10.1.tgz",
-          "integrity": "sha512-dqQj475q8+/avvok72CF3AOSV/SGEcH29zT5hhohqqvvZ2+boQoOr7iGldBG5YXTO2qgCgc2B3WvVLUdbeMlGA==",
-          "requires": {
-            "@babel/helper-plugin-utils": "^7.10.1",
-            "@babel/plugin-syntax-optional-chaining": "^7.8.0"
-          }
-        },
-        "@babel/plugin-proposal-unicode-property-regex": {
-          "version": "7.10.1",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.10.1.tgz",
-          "integrity": "sha512-JjfngYRvwmPwmnbRZyNiPFI8zxCZb8euzbCG/LxyKdeTb59tVciKo9GK9bi6JYKInk1H11Dq9j/zRqIH4KigfQ==",
-          "requires": {
-            "@babel/helper-create-regexp-features-plugin": "^7.10.1",
-            "@babel/helper-plugin-utils": "^7.10.1"
-          }
-        },
-        "@babel/plugin-syntax-top-level-await": {
-          "version": "7.10.1",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.10.1.tgz",
-          "integrity": "sha512-hgA5RYkmZm8FTFT3yu2N9Bx7yVVOKYT6yEdXXo6j2JTm0wNxgqaGeQVaSHRjhfnQbX91DtjFB6McRFSlcJH3xQ==",
-          "requires": {
-            "@babel/helper-plugin-utils": "^7.10.1"
-          }
-        },
-        "@babel/plugin-syntax-typescript": {
-          "version": "7.10.1",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.10.1.tgz",
-          "integrity": "sha512-X/d8glkrAtra7CaQGMiGs/OGa6XgUzqPcBXCIGFCpCqnfGlT0Wfbzo/B89xHhnInTaItPK8LALblVXcUOEh95Q==",
-          "requires": {
-            "@babel/helper-plugin-utils": "^7.10.1"
-          }
-        },
-        "@babel/plugin-transform-arrow-functions": {
-          "version": "7.10.1",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.10.1.tgz",
-          "integrity": "sha512-6AZHgFJKP3DJX0eCNJj01RpytUa3SOGawIxweHkNX2L6PYikOZmoh5B0d7hIHaIgveMjX990IAa/xK7jRTN8OA==",
-          "requires": {
-            "@babel/helper-plugin-utils": "^7.10.1"
-          }
-        },
-        "@babel/plugin-transform-async-to-generator": {
-          "version": "7.10.1",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.10.1.tgz",
-          "integrity": "sha512-XCgYjJ8TY2slj6SReBUyamJn3k2JLUIiiR5b6t1mNCMSvv7yx+jJpaewakikp0uWFQSF7ChPPoe3dHmXLpISkg==",
-          "requires": {
-            "@babel/helper-module-imports": "^7.10.1",
-            "@babel/helper-plugin-utils": "^7.10.1",
-            "@babel/helper-remap-async-to-generator": "^7.10.1"
-          }
-        },
-        "@babel/plugin-transform-block-scoped-functions": {
-          "version": "7.10.1",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.10.1.tgz",
-          "integrity": "sha512-B7K15Xp8lv0sOJrdVAoukKlxP9N59HS48V1J3U/JGj+Ad+MHq+am6xJVs85AgXrQn4LV8vaYFOB+pr/yIuzW8Q==",
-          "requires": {
-            "@babel/helper-plugin-utils": "^7.10.1"
-          }
-        },
-        "@babel/plugin-transform-block-scoping": {
-          "version": "7.10.1",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.10.1.tgz",
-          "integrity": "sha512-8bpWG6TtF5akdhIm/uWTyjHqENpy13Fx8chg7pFH875aNLwX8JxIxqm08gmAT+Whe6AOmaTeLPe7dpLbXt+xUw==",
-          "requires": {
-            "@babel/helper-plugin-utils": "^7.10.1",
-            "lodash": "^4.17.13"
-          }
-        },
-        "@babel/plugin-transform-classes": {
-          "version": "7.10.1",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.10.1.tgz",
-          "integrity": "sha512-P9V0YIh+ln/B3RStPoXpEQ/CoAxQIhRSUn7aXqQ+FZJ2u8+oCtjIXR3+X0vsSD8zv+mb56K7wZW1XiDTDGiDRQ==",
-          "requires": {
-            "@babel/helper-annotate-as-pure": "^7.10.1",
-            "@babel/helper-define-map": "^7.10.1",
-            "@babel/helper-function-name": "^7.10.1",
-            "@babel/helper-optimise-call-expression": "^7.10.1",
-            "@babel/helper-plugin-utils": "^7.10.1",
-            "@babel/helper-replace-supers": "^7.10.1",
-            "@babel/helper-split-export-declaration": "^7.10.1",
-            "globals": "^11.1.0"
-          }
-        },
-        "@babel/plugin-transform-computed-properties": {
-          "version": "7.10.1",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.10.1.tgz",
-          "integrity": "sha512-mqSrGjp3IefMsXIenBfGcPXxJxweQe2hEIwMQvjtiDQ9b1IBvDUjkAtV/HMXX47/vXf14qDNedXsIiNd1FmkaQ==",
-          "requires": {
-            "@babel/helper-plugin-utils": "^7.10.1"
-          }
-        },
-        "@babel/plugin-transform-destructuring": {
-          "version": "7.10.1",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.10.1.tgz",
-          "integrity": "sha512-V/nUc4yGWG71OhaTH705pU8ZSdM6c1KmmLP8ys59oOYbT7RpMYAR3MsVOt6OHL0WzG7BlTU076va9fjJyYzJMA==",
-          "requires": {
-            "@babel/helper-plugin-utils": "^7.10.1"
-          }
-        },
-        "@babel/plugin-transform-dotall-regex": {
-          "version": "7.10.1",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.10.1.tgz",
-          "integrity": "sha512-19VIMsD1dp02RvduFUmfzj8uknaO3uiHHF0s3E1OHnVsNj8oge8EQ5RzHRbJjGSetRnkEuBYO7TG1M5kKjGLOA==",
-          "requires": {
-            "@babel/helper-create-regexp-features-plugin": "^7.10.1",
-            "@babel/helper-plugin-utils": "^7.10.1"
-          }
-        },
-        "@babel/plugin-transform-duplicate-keys": {
-          "version": "7.10.1",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.10.1.tgz",
-          "integrity": "sha512-wIEpkX4QvX8Mo9W6XF3EdGttrIPZWozHfEaDTU0WJD/TDnXMvdDh30mzUl/9qWhnf7naicYartcEfUghTCSNpA==",
-          "requires": {
-            "@babel/helper-plugin-utils": "^7.10.1"
-          }
-        },
-        "@babel/plugin-transform-exponentiation-operator": {
-          "version": "7.10.1",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.10.1.tgz",
-          "integrity": "sha512-lr/przdAbpEA2BUzRvjXdEDLrArGRRPwbaF9rvayuHRvdQ7lUTTkZnhZrJ4LE2jvgMRFF4f0YuPQ20vhiPYxtA==",
-          "requires": {
-            "@babel/helper-builder-binary-assignment-operator-visitor": "^7.10.1",
-            "@babel/helper-plugin-utils": "^7.10.1"
-          }
-        },
-        "@babel/plugin-transform-for-of": {
-          "version": "7.10.1",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.10.1.tgz",
-          "integrity": "sha512-US8KCuxfQcn0LwSCMWMma8M2R5mAjJGsmoCBVwlMygvmDUMkTCykc84IqN1M7t+agSfOmLYTInLCHJM+RUoz+w==",
-          "requires": {
-            "@babel/helper-plugin-utils": "^7.10.1"
-          }
-        },
-        "@babel/plugin-transform-function-name": {
-          "version": "7.10.1",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.10.1.tgz",
-          "integrity": "sha512-//bsKsKFBJfGd65qSNNh1exBy5Y9gD9ZN+DvrJ8f7HXr4avE5POW6zB7Rj6VnqHV33+0vXWUwJT0wSHubiAQkw==",
-          "requires": {
-            "@babel/helper-function-name": "^7.10.1",
-            "@babel/helper-plugin-utils": "^7.10.1"
-          }
-        },
-        "@babel/plugin-transform-literals": {
-          "version": "7.10.1",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.10.1.tgz",
-          "integrity": "sha512-qi0+5qgevz1NHLZroObRm5A+8JJtibb7vdcPQF1KQE12+Y/xxl8coJ+TpPW9iRq+Mhw/NKLjm+5SHtAHCC7lAw==",
-          "requires": {
-            "@babel/helper-plugin-utils": "^7.10.1"
-          }
-        },
-        "@babel/plugin-transform-member-expression-literals": {
-          "version": "7.10.1",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.10.1.tgz",
-          "integrity": "sha512-UmaWhDokOFT2GcgU6MkHC11i0NQcL63iqeufXWfRy6pUOGYeCGEKhvfFO6Vz70UfYJYHwveg62GS83Rvpxn+NA==",
-          "requires": {
-            "@babel/helper-plugin-utils": "^7.10.1"
-          }
-        },
-        "@babel/plugin-transform-modules-amd": {
-          "version": "7.10.1",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.10.1.tgz",
-          "integrity": "sha512-31+hnWSFRI4/ACFr1qkboBbrTxoBIzj7qA69qlq8HY8p7+YCzkCT6/TvQ1a4B0z27VeWtAeJd6pr5G04dc1iHw==",
-          "requires": {
-            "@babel/helper-module-transforms": "^7.10.1",
-            "@babel/helper-plugin-utils": "^7.10.1",
-            "babel-plugin-dynamic-import-node": "^2.3.3"
-          }
-        },
-        "@babel/plugin-transform-modules-commonjs": {
-          "version": "7.10.1",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.10.1.tgz",
-          "integrity": "sha512-AQG4fc3KOah0vdITwt7Gi6hD9BtQP/8bhem7OjbaMoRNCH5Djx42O2vYMfau7QnAzQCa+RJnhJBmFFMGpQEzrg==",
-          "requires": {
-            "@babel/helper-module-transforms": "^7.10.1",
-            "@babel/helper-plugin-utils": "^7.10.1",
-            "@babel/helper-simple-access": "^7.10.1",
-            "babel-plugin-dynamic-import-node": "^2.3.3"
-          }
-        },
-        "@babel/plugin-transform-modules-systemjs": {
-          "version": "7.10.1",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.10.1.tgz",
-          "integrity": "sha512-ewNKcj1TQZDL3YnO85qh9zo1YF1CHgmSTlRQgHqe63oTrMI85cthKtZjAiZSsSNjPQ5NCaYo5QkbYqEw1ZBgZA==",
-          "requires": {
-            "@babel/helper-hoist-variables": "^7.10.1",
-            "@babel/helper-module-transforms": "^7.10.1",
-            "@babel/helper-plugin-utils": "^7.10.1",
-            "babel-plugin-dynamic-import-node": "^2.3.3"
-          }
-        },
-        "@babel/plugin-transform-modules-umd": {
-          "version": "7.10.1",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.10.1.tgz",
-          "integrity": "sha512-EIuiRNMd6GB6ulcYlETnYYfgv4AxqrswghmBRQbWLHZxN4s7mupxzglnHqk9ZiUpDI4eRWewedJJNj67PWOXKA==",
-          "requires": {
-            "@babel/helper-module-transforms": "^7.10.1",
-            "@babel/helper-plugin-utils": "^7.10.1"
-          }
-        },
-        "@babel/plugin-transform-new-target": {
-          "version": "7.10.1",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.10.1.tgz",
-          "integrity": "sha512-MBlzPc1nJvbmO9rPr1fQwXOM2iGut+JC92ku6PbiJMMK7SnQc1rytgpopveE3Evn47gzvGYeCdgfCDbZo0ecUw==",
-          "requires": {
-            "@babel/helper-plugin-utils": "^7.10.1"
-          }
-        },
-        "@babel/plugin-transform-object-super": {
-          "version": "7.10.1",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.10.1.tgz",
-          "integrity": "sha512-WnnStUDN5GL+wGQrJylrnnVlFhFmeArINIR9gjhSeYyvroGhBrSAXYg/RHsnfzmsa+onJrTJrEClPzgNmmQ4Gw==",
-          "requires": {
-            "@babel/helper-plugin-utils": "^7.10.1",
-            "@babel/helper-replace-supers": "^7.10.1"
-          }
-        },
-        "@babel/plugin-transform-parameters": {
-          "version": "7.10.1",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.10.1.tgz",
-          "integrity": "sha512-tJ1T0n6g4dXMsL45YsSzzSDZCxiHXAQp/qHrucOq5gEHncTA3xDxnd5+sZcoQp+N1ZbieAaB8r/VUCG0gqseOg==",
-          "requires": {
-            "@babel/helper-get-function-arity": "^7.10.1",
-            "@babel/helper-plugin-utils": "^7.10.1"
-          }
-        },
-        "@babel/plugin-transform-property-literals": {
-          "version": "7.10.1",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.10.1.tgz",
-          "integrity": "sha512-Kr6+mgag8auNrgEpbfIWzdXYOvqDHZOF0+Bx2xh4H2EDNwcbRb9lY6nkZg8oSjsX+DH9Ebxm9hOqtKW+gRDeNA==",
-          "requires": {
-            "@babel/helper-plugin-utils": "^7.10.1"
-          }
-        },
-        "@babel/plugin-transform-regenerator": {
-          "version": "7.10.1",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.10.1.tgz",
-          "integrity": "sha512-B3+Y2prScgJ2Bh/2l9LJxKbb8C8kRfsG4AdPT+n7ixBHIxJaIG8bi8tgjxUMege1+WqSJ+7gu1YeoMVO3gPWzw==",
-          "requires": {
-            "regenerator-transform": "^0.14.2"
-          }
-        },
-        "@babel/plugin-transform-reserved-words": {
-          "version": "7.10.1",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.10.1.tgz",
-          "integrity": "sha512-qN1OMoE2nuqSPmpTqEM7OvJ1FkMEV+BjVeZZm9V9mq/x1JLKQ4pcv8riZJMNN3u2AUGl0ouOMjRr2siecvHqUQ==",
-          "requires": {
-            "@babel/helper-plugin-utils": "^7.10.1"
-          }
-        },
-        "@babel/plugin-transform-runtime": {
-          "version": "7.10.1",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.10.1.tgz",
-          "integrity": "sha512-4w2tcglDVEwXJ5qxsY++DgWQdNJcCCsPxfT34wCUwIf2E7dI7pMpH8JczkMBbgBTNzBX62SZlNJ9H+De6Zebaw==",
-          "requires": {
-            "@babel/helper-module-imports": "^7.10.1",
-            "@babel/helper-plugin-utils": "^7.10.1",
-            "resolve": "^1.8.1",
-            "semver": "^5.5.1"
-          }
-        },
-        "@babel/plugin-transform-shorthand-properties": {
-          "version": "7.10.1",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.10.1.tgz",
-          "integrity": "sha512-AR0E/lZMfLstScFwztApGeyTHJ5u3JUKMjneqRItWeEqDdHWZwAOKycvQNCasCK/3r5YXsuNG25funcJDu7Y2g==",
-          "requires": {
-            "@babel/helper-plugin-utils": "^7.10.1"
-          }
-        },
-        "@babel/plugin-transform-spread": {
-          "version": "7.10.1",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.10.1.tgz",
-          "integrity": "sha512-8wTPym6edIrClW8FI2IoaePB91ETOtg36dOkj3bYcNe7aDMN2FXEoUa+WrmPc4xa1u2PQK46fUX2aCb+zo9rfw==",
-          "requires": {
-            "@babel/helper-plugin-utils": "^7.10.1"
-          }
-        },
-        "@babel/plugin-transform-sticky-regex": {
-          "version": "7.10.1",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.10.1.tgz",
-          "integrity": "sha512-j17ojftKjrL7ufX8ajKvwRilwqTok4q+BjkknmQw9VNHnItTyMP5anPFzxFJdCQs7clLcWpCV3ma+6qZWLnGMA==",
-          "requires": {
-            "@babel/helper-plugin-utils": "^7.10.1",
-            "@babel/helper-regex": "^7.10.1"
-          }
-        },
-        "@babel/plugin-transform-template-literals": {
-          "version": "7.10.1",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.10.1.tgz",
-          "integrity": "sha512-t7B/3MQf5M1T9hPCRG28DNGZUuxAuDqLYS03rJrIk2prj/UV7Z6FOneijhQhnv/Xa039vidXeVbvjK2SK5f7Gg==",
-          "requires": {
-            "@babel/helper-annotate-as-pure": "^7.10.1",
-            "@babel/helper-plugin-utils": "^7.10.1"
-          }
-        },
-        "@babel/plugin-transform-typeof-symbol": {
-          "version": "7.10.1",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.10.1.tgz",
-          "integrity": "sha512-qX8KZcmbvA23zDi+lk9s6hC1FM7jgLHYIjuLgULgc8QtYnmB3tAVIYkNoKRQ75qWBeyzcoMoK8ZQmogGtC/w0g==",
-          "requires": {
-            "@babel/helper-plugin-utils": "^7.10.1"
-          }
-        },
-        "@babel/plugin-transform-typescript": {
-          "version": "7.10.1",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.10.1.tgz",
-          "integrity": "sha512-v+QWKlmCnsaimLeqq9vyCsVRMViZG1k2SZTlcZvB+TqyH570Zsij8nvVUZzOASCRiQFUxkLrn9Wg/kH0zgy5OQ==",
-          "requires": {
-            "@babel/helper-create-class-features-plugin": "^7.10.1",
-            "@babel/helper-plugin-utils": "^7.10.1",
-            "@babel/plugin-syntax-typescript": "^7.10.1"
-          }
-        },
-        "@babel/plugin-transform-unicode-regex": {
-          "version": "7.10.1",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.10.1.tgz",
-          "integrity": "sha512-Y/2a2W299k0VIUdbqYm9X2qS6fE0CUBhhiPpimK6byy7OJ/kORLlIX+J6UrjgNu5awvs62k+6RSslxhcvVw2Tw==",
-          "requires": {
-            "@babel/helper-create-regexp-features-plugin": "^7.10.1",
-            "@babel/helper-plugin-utils": "^7.10.1"
-          }
-        },
-        "@babel/polyfill": {
-          "version": "7.10.1",
-          "resolved": "https://registry.npmjs.org/@babel/polyfill/-/polyfill-7.10.1.tgz",
-          "integrity": "sha512-TviueJ4PBW5p48ra8IMtLXVkDucrlOZAIZ+EXqS3Ot4eukHbWiqcn7DcqpA1k5PcKtmJ4Xl9xwdv6yQvvcA+3g==",
-          "requires": {
-            "core-js": "^2.6.5",
-            "regenerator-runtime": "^0.13.4"
-          }
-        },
-        "@babel/preset-env": {
-          "version": "7.10.2",
-          "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.10.2.tgz",
-          "integrity": "sha512-MjqhX0RZaEgK/KueRzh+3yPSk30oqDKJ5HP5tqTSB1e2gzGS3PLy7K0BIpnp78+0anFuSwOeuCf1zZO7RzRvEA==",
-          "requires": {
-            "@babel/compat-data": "^7.10.1",
-            "@babel/helper-compilation-targets": "^7.10.2",
-            "@babel/helper-module-imports": "^7.10.1",
-            "@babel/helper-plugin-utils": "^7.10.1",
-            "@babel/plugin-proposal-async-generator-functions": "^7.10.1",
-            "@babel/plugin-proposal-class-properties": "^7.10.1",
-            "@babel/plugin-proposal-dynamic-import": "^7.10.1",
-            "@babel/plugin-proposal-json-strings": "^7.10.1",
-            "@babel/plugin-proposal-nullish-coalescing-operator": "^7.10.1",
-            "@babel/plugin-proposal-numeric-separator": "^7.10.1",
-            "@babel/plugin-proposal-object-rest-spread": "^7.10.1",
-            "@babel/plugin-proposal-optional-catch-binding": "^7.10.1",
-            "@babel/plugin-proposal-optional-chaining": "^7.10.1",
-            "@babel/plugin-proposal-private-methods": "^7.10.1",
-            "@babel/plugin-proposal-unicode-property-regex": "^7.10.1",
-            "@babel/plugin-syntax-async-generators": "^7.8.0",
-            "@babel/plugin-syntax-class-properties": "^7.10.1",
-            "@babel/plugin-syntax-dynamic-import": "^7.8.0",
-            "@babel/plugin-syntax-json-strings": "^7.8.0",
-            "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.0",
-            "@babel/plugin-syntax-numeric-separator": "^7.10.1",
-            "@babel/plugin-syntax-object-rest-spread": "^7.8.0",
-            "@babel/plugin-syntax-optional-catch-binding": "^7.8.0",
-            "@babel/plugin-syntax-optional-chaining": "^7.8.0",
-            "@babel/plugin-syntax-top-level-await": "^7.10.1",
-            "@babel/plugin-transform-arrow-functions": "^7.10.1",
-            "@babel/plugin-transform-async-to-generator": "^7.10.1",
-            "@babel/plugin-transform-block-scoped-functions": "^7.10.1",
-            "@babel/plugin-transform-block-scoping": "^7.10.1",
-            "@babel/plugin-transform-classes": "^7.10.1",
-            "@babel/plugin-transform-computed-properties": "^7.10.1",
-            "@babel/plugin-transform-destructuring": "^7.10.1",
-            "@babel/plugin-transform-dotall-regex": "^7.10.1",
-            "@babel/plugin-transform-duplicate-keys": "^7.10.1",
-            "@babel/plugin-transform-exponentiation-operator": "^7.10.1",
-            "@babel/plugin-transform-for-of": "^7.10.1",
-            "@babel/plugin-transform-function-name": "^7.10.1",
-            "@babel/plugin-transform-literals": "^7.10.1",
-            "@babel/plugin-transform-member-expression-literals": "^7.10.1",
-            "@babel/plugin-transform-modules-amd": "^7.10.1",
-            "@babel/plugin-transform-modules-commonjs": "^7.10.1",
-            "@babel/plugin-transform-modules-systemjs": "^7.10.1",
-            "@babel/plugin-transform-modules-umd": "^7.10.1",
-            "@babel/plugin-transform-named-capturing-groups-regex": "^7.8.3",
-            "@babel/plugin-transform-new-target": "^7.10.1",
-            "@babel/plugin-transform-object-super": "^7.10.1",
-            "@babel/plugin-transform-parameters": "^7.10.1",
-            "@babel/plugin-transform-property-literals": "^7.10.1",
-            "@babel/plugin-transform-regenerator": "^7.10.1",
-            "@babel/plugin-transform-reserved-words": "^7.10.1",
-            "@babel/plugin-transform-shorthand-properties": "^7.10.1",
-            "@babel/plugin-transform-spread": "^7.10.1",
-            "@babel/plugin-transform-sticky-regex": "^7.10.1",
-            "@babel/plugin-transform-template-literals": "^7.10.1",
-            "@babel/plugin-transform-typeof-symbol": "^7.10.1",
-            "@babel/plugin-transform-unicode-escapes": "^7.10.1",
-            "@babel/plugin-transform-unicode-regex": "^7.10.1",
-            "@babel/preset-modules": "^0.1.3",
-            "@babel/types": "^7.10.2",
-            "browserslist": "^4.12.0",
-            "core-js-compat": "^3.6.2",
-            "invariant": "^2.2.2",
-            "levenary": "^1.1.1",
-            "semver": "^5.5.0"
-          },
-          "dependencies": {
-            "@babel/plugin-proposal-class-properties": {
-              "version": "7.10.1",
-              "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.10.1.tgz",
-              "integrity": "sha512-sqdGWgoXlnOdgMXU+9MbhzwFRgxVLeiGBqTrnuS7LC2IBU31wSsESbTUreT2O418obpfPdGUR2GbEufZF1bpqw==",
-              "requires": {
-                "@babel/helper-create-class-features-plugin": "^7.10.1",
-                "@babel/helper-plugin-utils": "^7.10.1"
-              }
-            }
-          }
-        },
-        "@babel/runtime": {
-          "version": "7.10.2",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.10.2.tgz",
-          "integrity": "sha512-6sF3uQw2ivImfVIl62RZ7MXhO2tap69WeWK57vAaimT6AZbE4FbqjdEJIN1UqoD6wI6B+1n9UiagafH1sxjOtg==",
-          "requires": {
-            "regenerator-runtime": "^0.13.4"
-          }
-        },
-        "@babel/template": {
-          "version": "7.10.1",
-          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.10.1.tgz",
-          "integrity": "sha512-OQDg6SqvFSsc9A0ej6SKINWrpJiNonRIniYondK2ViKhB06i3c0s+76XUft71iqBEe9S1OKsHwPAjfHnuvnCig==",
-          "requires": {
-            "@babel/code-frame": "^7.10.1",
-            "@babel/parser": "^7.10.1",
-            "@babel/types": "^7.10.1"
-          }
-        },
-        "@babel/traverse": {
-          "version": "7.10.1",
-          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.10.1.tgz",
-          "integrity": "sha512-C/cTuXeKt85K+p08jN6vMDz8vSV0vZcI0wmQ36o6mjbuo++kPMdpOYw23W2XH04dbRt9/nMEfA4W3eR21CD+TQ==",
-          "requires": {
-            "@babel/code-frame": "^7.10.1",
-            "@babel/generator": "^7.10.1",
-            "@babel/helper-function-name": "^7.10.1",
-            "@babel/helper-split-export-declaration": "^7.10.1",
-            "@babel/parser": "^7.10.1",
-            "@babel/types": "^7.10.1",
-            "debug": "^4.1.0",
-            "globals": "^11.1.0",
-            "lodash": "^4.17.13"
-          }
-        },
-        "@babel/types": {
-          "version": "7.10.2",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.10.2.tgz",
-          "integrity": "sha512-AD3AwWBSz0AWF0AkCN9VPiWrvldXq+/e3cHa4J89vo4ymjz1XwrBFFVZmkJTsQIPNk+ZVomPSXUJqq8yyjZsng==",
-          "requires": {
-            "@babel/helper-validator-identifier": "^7.10.1",
-            "lodash": "^4.17.13",
-            "to-fast-properties": "^2.0.0"
-          }
-        },
-        "babel-plugin-dynamic-import-node": {
-          "version": "2.3.3",
-          "resolved": "https://registry.npmjs.org/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.3.tgz",
-          "integrity": "sha512-jZVI+s9Zg3IqA/kdi0i6UDCybUI3aSBLnglhYbSSjKlV7yF1F/5LWv8MakQmvYpnbJDS6fcBL2KzHSxNCMtWSQ==",
-          "requires": {
-            "object.assign": "^4.1.0"
-          }
-        },
-        "babel-plugin-ember-data-packages-polyfill": {
-          "version": "0.1.2",
-          "resolved": "https://registry.npmjs.org/babel-plugin-ember-data-packages-polyfill/-/babel-plugin-ember-data-packages-polyfill-0.1.2.tgz",
-          "integrity": "sha512-kTHnOwoOXfPXi00Z8yAgyD64+jdSXk3pknnS7NlqnCKAU6YDkXZ4Y7irl66kaZjZn0FBBt0P4YOZFZk85jYOww==",
-          "requires": {
-            "@ember-data/rfc395-data": "^0.0.4"
-          }
-        },
-        "babel-plugin-ember-modules-api-polyfill": {
-          "version": "2.13.4",
-          "resolved": "https://registry.npmjs.org/babel-plugin-ember-modules-api-polyfill/-/babel-plugin-ember-modules-api-polyfill-2.13.4.tgz",
-          "integrity": "sha512-uxQPkEQAzCYdwhZk16O9m1R4xtCRNy4oEUTBrccOPfzlIahRZJic/JeP/ZEL0BC6Mfq6r55eOg6gMF/zdFoCvA==",
-          "requires": {
-            "ember-rfc176-data": "^0.3.13"
-          }
-        },
-        "babel-plugin-htmlbars-inline-precompile": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/babel-plugin-htmlbars-inline-precompile/-/babel-plugin-htmlbars-inline-precompile-3.1.0.tgz",
-          "integrity": "sha512-ar6c4YVX6OV7Dzpq7xRyllQrHwVEzJf41qysYULnD6tu6TS+y1FxT2VcEvMC6b9Rq9xoHMzvB79HO3av89JCGg=="
-        },
-        "broccoli-plugin": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-3.1.0.tgz",
-          "integrity": "sha512-7w7FP8WJYjLvb0eaw27LO678TGGaom++49O1VYIuzjhXjK5kn2+AMlDm7CaUFw4F7CLGoVQeZ84d8gICMJa4lA==",
-          "requires": {
-            "broccoli-node-api": "^1.6.0",
-            "broccoli-output-wrapper": "^2.0.0",
-            "fs-merger": "^3.0.1",
-            "promise-map-series": "^0.2.1",
-            "quick-temp": "^0.1.3",
-            "rimraf": "^2.3.4",
-            "symlink-or-copy": "^1.1.8"
-          },
-          "dependencies": {
-            "rimraf": {
-              "version": "2.7.1",
-              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-              "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-              "requires": {
-                "glob": "^7.1.3"
-              }
-            }
-          }
-        },
-        "browserslist": {
-          "version": "4.12.0",
-          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.12.0.tgz",
-          "integrity": "sha512-UH2GkcEDSI0k/lRkuDSzFl9ZZ87skSy9w2XAn1MsZnL+4c4rqbBd3e82UWHbYDpztABrPBhZsTEeuxVfHppqDg==",
-          "requires": {
-            "caniuse-lite": "^1.0.30001043",
-            "electron-to-chromium": "^1.3.413",
-            "node-releases": "^1.1.53",
-            "pkg-up": "^2.0.0"
-          }
-        },
-        "caniuse-lite": {
-          "version": "1.0.30001077",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001077.tgz",
-          "integrity": "sha512-AEzsGvjBJL0lby/87W96PyEvwN0GsYvk5LHsglLg9tW37K4BqvAvoSCdWIE13OZQ8afupqZ73+oL/1LkedN8hA=="
-        },
-        "electron-to-chromium": {
-          "version": "1.3.458",
-          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.458.tgz",
-          "integrity": "sha512-OjRkb0igW0oKE2QbzS7vBYrm7xjW/KRTtIj0OGGx57jr/YhBiKb7oZvdbaojqjfCb/7LbnwsbMbdsYjthdJbAw=="
-        },
-        "ember-cli-babel": {
-          "version": "7.20.5",
-          "resolved": "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-7.20.5.tgz",
-          "integrity": "sha512-lWvKqJPQ1KJigWKmxREqFbXgZd2/nFKMg3chiiNejpsAIgGLPXGFLwpMQ7QYCRrlims7D/bnDgFvXuOLkw0fcQ==",
-          "requires": {
-            "@babel/core": "^7.9.0",
-            "@babel/helper-compilation-targets": "^7.8.7",
-            "@babel/plugin-proposal-class-properties": "^7.8.3",
-            "@babel/plugin-proposal-decorators": "^7.8.3",
-            "@babel/plugin-transform-modules-amd": "^7.9.0",
-            "@babel/plugin-transform-runtime": "^7.9.0",
-            "@babel/plugin-transform-typescript": "^7.9.0",
-            "@babel/polyfill": "^7.8.7",
-            "@babel/preset-env": "^7.9.0",
-            "@babel/runtime": "^7.9.0",
-            "amd-name-resolver": "^1.2.1",
-            "babel-plugin-debug-macros": "^0.3.0",
-            "babel-plugin-ember-data-packages-polyfill": "^0.1.2",
-            "babel-plugin-ember-modules-api-polyfill": "^2.13.4",
-            "babel-plugin-module-resolver": "^3.1.1",
-            "broccoli-babel-transpiler": "^7.4.0",
-            "broccoli-debug": "^0.6.4",
-            "broccoli-funnel": "^2.0.1",
-            "broccoli-source": "^1.1.0",
-            "clone": "^2.1.2",
-            "ember-cli-babel-plugin-helpers": "^1.1.0",
-            "ember-cli-version-checker": "^4.1.0",
-            "ensure-posix-path": "^1.0.2",
-            "fixturify-project": "^1.10.0",
-            "rimraf": "^3.0.1",
-            "semver": "^5.5.0"
-          },
-          "dependencies": {
-            "ember-cli-version-checker": {
-              "version": "4.1.1",
-              "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-4.1.1.tgz",
-              "integrity": "sha512-bzEWsTMXUGEJfxcAGWPe6kI7oHEGD3jaxUWDYPTqzqGhNkgPwXTBgoWs9zG1RaSMaOPFnloWuxRcoHi4TrYS3Q==",
-              "requires": {
-                "resolve-package-path": "^2.0.0",
-                "semver": "^6.3.0",
-                "silent-error": "^1.1.1"
-              },
-              "dependencies": {
-                "semver": {
-                  "version": "6.3.0",
-                  "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-                  "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
-                }
-              }
-            }
-          }
-        },
-        "ember-cli-htmlbars": {
-          "version": "4.3.1",
-          "resolved": "https://registry.npmjs.org/ember-cli-htmlbars/-/ember-cli-htmlbars-4.3.1.tgz",
-          "integrity": "sha512-CW6AY/yzjeVqoRtItOKj3hcYzc5dWPRETmeCzr2Iqjt5vxiVtpl0z5VTqHqIlT5fsFx6sGWBQXNHIe+ivYsxXQ==",
-          "requires": {
-            "@ember/edition-utils": "^1.2.0",
-            "babel-plugin-htmlbars-inline-precompile": "^3.0.1",
-            "broccoli-debug": "^0.6.5",
-            "broccoli-persistent-filter": "^2.3.1",
-            "broccoli-plugin": "^3.1.0",
-            "common-tags": "^1.8.0",
-            "ember-cli-babel-plugin-helpers": "^1.1.0",
-            "fs-tree-diff": "^2.0.1",
-            "hash-for-dep": "^1.5.1",
-            "heimdalljs-logger": "^0.1.10",
-            "json-stable-stringify": "^1.0.1",
-            "semver": "^6.3.0",
-            "strip-bom": "^4.0.0",
-            "walk-sync": "^2.0.2"
-          },
-          "dependencies": {
-            "semver": {
-              "version": "6.3.0",
-              "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-              "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
-            }
-          }
-        },
-        "ember-cli-version-checker": {
-          "version": "5.1.1",
-          "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-5.1.1.tgz",
-          "integrity": "sha512-YziSW1MgOuVdJSyUY2CKSC4vXrGQIHF6FgygHkJOxYGjZNQYwf5MK0sbliKatvJf7kzDSnXs+r8JLrD74W/A8A==",
-          "requires": {
-            "resolve-package-path": "^2.0.0",
-            "semver": "^7.3.2",
-            "silent-error": "^1.1.1"
-          },
-          "dependencies": {
-            "semver": {
-              "version": "7.3.2",
-              "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
-              "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ=="
-            }
-          }
-        },
-        "ember-rfc176-data": {
-          "version": "0.3.13",
-          "resolved": "https://registry.npmjs.org/ember-rfc176-data/-/ember-rfc176-data-0.3.13.tgz",
-          "integrity": "sha512-m9JbwQlT6PjY7x/T8HslnXP7Sz9bx/pz3FrNfNi2NesJnbNISly0Lix6NV1fhfo46572cpq4jrM+/6yYlMefTQ=="
-        },
-        "fs-tree-diff": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/fs-tree-diff/-/fs-tree-diff-2.0.1.tgz",
-          "integrity": "sha512-x+CfAZ/lJHQqwlD64pYM5QxWjzWhSjroaVsr8PW831zOApL55qPibed0c+xebaLWVr2BnHFoHdrwOv8pzt8R5A==",
-          "requires": {
-            "@types/symlink-or-copy": "^1.2.0",
-            "heimdalljs-logger": "^0.1.7",
-            "object-assign": "^4.1.0",
-            "path-posix": "^1.0.0",
-            "symlink-or-copy": "^1.1.8"
-          }
-        },
-        "json5": {
-          "version": "2.1.3",
-          "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.3.tgz",
-          "integrity": "sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==",
-          "requires": {
-            "minimist": "^1.2.5"
-          }
-        },
-        "matcher-collection": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/matcher-collection/-/matcher-collection-2.0.1.tgz",
-          "integrity": "sha512-daE62nS2ZQsDg9raM0IlZzLmI2u+7ZapXBwdoeBUKAYERPDDIc0qNqA8E0Rp2D+gspKR7BgIFP52GeujaGXWeQ==",
-          "requires": {
-            "@types/minimatch": "^3.0.3",
-            "minimatch": "^3.0.2"
-          }
-        },
-        "minimist": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
-        },
-        "node-releases": {
-          "version": "1.1.58",
-          "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.58.tgz",
-          "integrity": "sha512-NxBudgVKiRh/2aPWMgPR7bPTX0VPmGx5QBwCtdHitnqFE5/O8DeBXuIMH1nwNnw/aMo6AjOrpsHzfY3UbUJ7yg=="
-        },
-        "regenerate-unicode-properties": {
-          "version": "8.2.0",
-          "resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-8.2.0.tgz",
-          "integrity": "sha512-F9DjY1vKLo/tPePDycuH3dn9H1OTPIkVD9Kz4LODu+F2C75mgjAJ7x/gwy6ZcSNRAAkhNlJSOHRe8k3p+K9WhA==",
-          "requires": {
-            "regenerate": "^1.4.0"
-          }
-        },
-        "regenerator-runtime": {
-          "version": "0.13.5",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
-          "integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA=="
-        },
-        "regenerator-transform": {
-          "version": "0.14.4",
-          "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.14.4.tgz",
-          "integrity": "sha512-EaJaKPBI9GvKpvUz2mz4fhx7WPgvwRLY9v3hlNHWmAuJHI13T4nwKnNvm5RWJzEdnI5g5UwtOww+S8IdoUC2bw==",
-          "requires": {
-            "@babel/runtime": "^7.8.4",
-            "private": "^0.1.8"
-          }
-        },
-        "regexpu-core": {
-          "version": "4.7.0",
-          "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.7.0.tgz",
-          "integrity": "sha512-TQ4KXRnIn6tz6tjnrXEkD/sshygKH/j5KzK86X8MkeHyZ8qst/LZ89j3X4/8HEIfHANTFIP/AbXakeRhWIl5YQ==",
-          "requires": {
-            "regenerate": "^1.4.0",
-            "regenerate-unicode-properties": "^8.2.0",
-            "regjsgen": "^0.5.1",
-            "regjsparser": "^0.6.4",
-            "unicode-match-property-ecmascript": "^1.0.4",
-            "unicode-match-property-value-ecmascript": "^1.2.0"
-          }
-        },
-        "regjsparser": {
-          "version": "0.6.4",
-          "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.6.4.tgz",
-          "integrity": "sha512-64O87/dPDgfk8/RQqC4gkZoGyyWFIEUTTh80CU6CWuK5vkCGyekIx+oKcEIYtP/RAxSQltCZHCNu/mdd7fqlJw==",
-          "requires": {
-            "jsesc": "~0.5.0"
-          },
-          "dependencies": {
-            "jsesc": {
-              "version": "0.5.0",
-              "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
-              "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0="
-            }
-          }
-        },
-        "resolve-package-path": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/resolve-package-path/-/resolve-package-path-2.0.0.tgz",
-          "integrity": "sha512-/CLuzodHO2wyyHTzls5Qr+EFeG6RcW4u6//gjYvUfcfyuplIX1SSccU+A5A9A78Gmezkl3NBkFAMxLbzTY9TJA==",
-          "requires": {
-            "path-root": "^0.1.1",
-            "resolve": "^1.13.1"
-          }
-        },
-        "strip-bom": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
-          "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w=="
-        },
-        "unicode-match-property-value-ecmascript": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-1.2.0.tgz",
-          "integrity": "sha512-wjuQHGQVofmSJv1uVISKLE5zO2rNGzM/KCYZch/QQvez7C1hUhBIuZ701fYXExuufJFMPhv2SyL8CyoIfMLbIQ=="
-        },
-        "walk-sync": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-2.1.0.tgz",
-          "integrity": "sha512-KpH9Xw64LNSx7/UI+3guRZvJWlDxVA4+KKb/4puRoVrG8GkvZRxnF3vhxdjgpoKJGL2TVg1OrtkXIE/VuGPLHQ==",
-          "requires": {
-            "@types/minimatch": "^3.0.3",
-            "ensure-posix-path": "^1.1.0",
-            "matcher-collection": "^2.0.0"
           }
         }
       }
@@ -14428,6 +15135,15 @@
             "semver": "^5.3.0"
           }
         },
+        "babel-plugin-ember-modules-api-polyfill": {
+          "version": "2.13.4",
+          "resolved": "https://registry.npmjs.org/babel-plugin-ember-modules-api-polyfill/-/babel-plugin-ember-modules-api-polyfill-2.13.4.tgz",
+          "integrity": "sha512-uxQPkEQAzCYdwhZk16O9m1R4xtCRNy4oEUTBrccOPfzlIahRZJic/JeP/ZEL0BC6Mfq6r55eOg6gMF/zdFoCvA==",
+          "dev": true,
+          "requires": {
+            "ember-rfc176-data": "^0.3.13"
+          }
+        },
         "broccoli-babel-transpiler": {
           "version": "6.5.1",
           "resolved": "https://registry.npmjs.org/broccoli-babel-transpiler/-/broccoli-babel-transpiler-6.5.1.tgz",
@@ -14458,6 +15174,27 @@
             }
           }
         },
+        "broccoli-funnel": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-2.0.2.tgz",
+          "integrity": "sha512-/vDTqtv7ipjEZQOVqO4vGDVAOZyuYzQ/EgGoyewfOgh1M7IQAToBKZI0oAQPgMBeFPPlIbfMuAngk+ohPBuaHQ==",
+          "dev": true,
+          "requires": {
+            "array-equal": "^1.0.0",
+            "blank-object": "^1.0.1",
+            "broccoli-plugin": "^1.3.0",
+            "debug": "^2.2.0",
+            "fast-ordered-set": "^1.0.0",
+            "fs-tree-diff": "^0.5.3",
+            "heimdalljs": "^0.2.0",
+            "minimatch": "^3.0.0",
+            "mkdirp": "^0.5.0",
+            "path-posix": "^1.0.0",
+            "rimraf": "^2.4.3",
+            "symlink-or-copy": "^1.0.0",
+            "walk-sync": "^0.3.1"
+          }
+        },
         "broccoli-persistent-filter": {
           "version": "1.4.6",
           "resolved": "https://registry.npmjs.org/broccoli-persistent-filter/-/broccoli-persistent-filter-1.4.6.tgz",
@@ -14485,6 +15222,15 @@
               "integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw==",
               "dev": true
             }
+          }
+        },
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
           }
         },
         "ember-cli-babel": {
@@ -14531,6 +15277,12 @@
             "rimraf": "^2.4.3",
             "symlink-or-copy": "^1.0.0"
           }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
         },
         "rimraf": {
           "version": "2.7.1",
@@ -14590,6 +15342,23 @@
           "dev": true,
           "requires": {
             "semver": "^5.3.0"
+          },
+          "dependencies": {
+            "semver": {
+              "version": "5.7.1",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+              "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+              "dev": true
+            }
+          }
+        },
+        "babel-plugin-ember-modules-api-polyfill": {
+          "version": "2.13.4",
+          "resolved": "https://registry.npmjs.org/babel-plugin-ember-modules-api-polyfill/-/babel-plugin-ember-modules-api-polyfill-2.13.4.tgz",
+          "integrity": "sha512-uxQPkEQAzCYdwhZk16O9m1R4xtCRNy4oEUTBrccOPfzlIahRZJic/JeP/ZEL0BC6Mfq6r55eOg6gMF/zdFoCvA==",
+          "dev": true,
+          "requires": {
+            "ember-rfc176-data": "^0.3.13"
           }
         },
         "broccoli-babel-transpiler": {
@@ -14710,6 +15479,11 @@
             }
           }
         },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        },
         "debug": {
           "version": "2.6.9",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -14760,24 +15534,56 @@
                 "symlink-or-copy": "^1.0.0",
                 "walk-sync": "^0.3.1"
               }
+            },
+            "ember-cli-version-checker": {
+              "version": "2.2.0",
+              "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-2.2.0.tgz",
+              "integrity": "sha512-G+KtYIVlSOWGcNaTFHk76xR4GdzDLzAS4uxZUKdASuFX0KJE43C6DaqL+y3VTpUFLI2FIkAS6HZ4I1YBi+S3hg==",
+              "dev": true,
+              "requires": {
+                "resolve": "^1.3.3",
+                "semver": "^5.3.0"
+              }
+            },
+            "semver": {
+              "version": "5.7.1",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+              "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+              "dev": true
             }
           }
         },
         "ember-cli-version-checker": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-2.2.0.tgz",
-          "integrity": "sha512-G+KtYIVlSOWGcNaTFHk76xR4GdzDLzAS4uxZUKdASuFX0KJE43C6DaqL+y3VTpUFLI2FIkAS6HZ4I1YBi+S3hg==",
-          "dev": true,
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-5.1.1.tgz",
+          "integrity": "sha512-YziSW1MgOuVdJSyUY2CKSC4vXrGQIHF6FgygHkJOxYGjZNQYwf5MK0sbliKatvJf7kzDSnXs+r8JLrD74W/A8A==",
           "requires": {
-            "resolve": "^1.3.3",
-            "semver": "^5.3.0"
+            "resolve-package-path": "^2.0.0",
+            "semver": "^7.3.2",
+            "silent-error": "^1.1.1"
+          },
+          "dependencies": {
+            "semver": {
+              "version": "7.3.2",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+              "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ=="
+            }
           }
         },
-        "exists-sync": {
-          "version": "0.0.4",
-          "resolved": "https://registry.npmjs.org/exists-sync/-/exists-sync-0.0.4.tgz",
-          "integrity": "sha1-l0TCxCjMA7AQYNtFTUsS8O88iHk=",
-          "dev": true
+        "fs-extra": {
+          "version": "8.1.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+          "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+          "requires": {
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^4.0.0",
+            "universalify": "^0.1.0"
+          }
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
         },
         "merge-trees": {
           "version": "1.0.1",
@@ -14805,6 +15611,23 @@
           "integrity": "sha1-0z65XQ0gAaS+OWWXB8UbDLcc4Ck=",
           "dev": true
         },
+        "resolve": {
+          "version": "1.17.0",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
+          "integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
+          "requires": {
+            "path-parse": "^1.0.6"
+          }
+        },
+        "resolve-package-path": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-package-path/-/resolve-package-path-2.0.0.tgz",
+          "integrity": "sha512-/CLuzodHO2wyyHTzls5Qr+EFeG6RcW4u6//gjYvUfcfyuplIX1SSccU+A5A9A78Gmezkl3NBkFAMxLbzTY9TJA==",
+          "requires": {
+            "path-root": "^0.1.1",
+            "resolve": "^1.13.1"
+          }
+        },
         "rimraf": {
           "version": "2.7.1",
           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
@@ -14812,6 +15635,19 @@
           "dev": true,
           "requires": {
             "glob": "^7.1.3"
+          }
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+        },
+        "supports-color": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "requires": {
+            "has-flag": "^4.0.0"
           }
         },
         "workerpool": {
@@ -14838,6 +15674,53 @@
         "ember-cli-babel": "^7.12.0",
         "ember-cli-test-loader": "^2.2.0",
         "qunit": "^2.9.3"
+      },
+      "dependencies": {
+        "broccoli-funnel": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-2.0.2.tgz",
+          "integrity": "sha512-/vDTqtv7ipjEZQOVqO4vGDVAOZyuYzQ/EgGoyewfOgh1M7IQAToBKZI0oAQPgMBeFPPlIbfMuAngk+ohPBuaHQ==",
+          "dev": true,
+          "requires": {
+            "array-equal": "^1.0.0",
+            "blank-object": "^1.0.1",
+            "broccoli-plugin": "^1.3.0",
+            "debug": "^2.2.0",
+            "fast-ordered-set": "^1.0.0",
+            "fs-tree-diff": "^0.5.3",
+            "heimdalljs": "^0.2.0",
+            "minimatch": "^3.0.0",
+            "mkdirp": "^0.5.0",
+            "path-posix": "^1.0.0",
+            "rimraf": "^2.4.3",
+            "symlink-or-copy": "^1.0.0",
+            "walk-sync": "^0.3.1"
+          }
+        },
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        },
+        "rimraf": {
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        }
       }
     },
     "ember-resolver": {
@@ -14993,9 +15876,10 @@
       }
     },
     "ember-rfc176-data": {
-      "version": "0.3.12",
-      "resolved": "https://registry.npmjs.org/ember-rfc176-data/-/ember-rfc176-data-0.3.12.tgz",
-      "integrity": "sha512-g9HeZj/gU5bfIIrGXkP7MhS2b3Vu5DfNUrYr14hy99TgIvtZETO+96QF4WOEUXGjIJdfTRjerVnQlqngPQSv1g=="
+      "version": "0.3.15",
+      "resolved": "https://registry.npmjs.org/ember-rfc176-data/-/ember-rfc176-data-0.3.15.tgz",
+      "integrity": "sha512-GPKa7zRDBblRy0orxTXt5yrpp/Pf5CkuRFSIR8qMFDww0CqCKjCRwdZnWYzCM4kAEfZnXRIDDefe1tBaFw7v7w==",
+      "dev": true
     },
     "ember-router-generator": {
       "version": "2.0.0",
@@ -15048,6 +15932,50 @@
           "requires": {
             "@types/color-name": "^1.1.1",
             "color-convert": "^2.0.1"
+          }
+        },
+        "broccoli-funnel": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-2.0.2.tgz",
+          "integrity": "sha512-/vDTqtv7ipjEZQOVqO4vGDVAOZyuYzQ/EgGoyewfOgh1M7IQAToBKZI0oAQPgMBeFPPlIbfMuAngk+ohPBuaHQ==",
+          "dev": true,
+          "requires": {
+            "array-equal": "^1.0.0",
+            "blank-object": "^1.0.1",
+            "broccoli-plugin": "^1.3.0",
+            "debug": "^2.2.0",
+            "fast-ordered-set": "^1.0.0",
+            "fs-tree-diff": "^0.5.3",
+            "heimdalljs": "^0.2.0",
+            "minimatch": "^3.0.0",
+            "mkdirp": "^0.5.0",
+            "path-posix": "^1.0.0",
+            "rimraf": "^2.4.3",
+            "symlink-or-copy": "^1.0.0",
+            "walk-sync": "^0.3.1"
+          },
+          "dependencies": {
+            "broccoli-plugin": {
+              "version": "1.3.1",
+              "resolved": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-1.3.1.tgz",
+              "integrity": "sha512-DW8XASZkmorp+q7J4EeDEZz+LoyKLAd2XZULXyD9l4m9/hAKV3vjHmB1kiUshcWAYMgTP1m2i4NnqCE/23h6AQ==",
+              "dev": true,
+              "requires": {
+                "promise-map-series": "^0.2.1",
+                "quick-temp": "^0.1.3",
+                "rimraf": "^2.3.4",
+                "symlink-or-copy": "^1.1.8"
+              }
+            },
+            "rimraf": {
+              "version": "2.7.1",
+              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+              "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+              "dev": true,
+              "requires": {
+                "glob": "^7.1.3"
+              }
+            }
           }
         },
         "broccoli-merge-trees": {
@@ -15111,6 +16039,15 @@
           "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
           "dev": true
         },
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
         "ember-cli-version-checker": {
           "version": "5.1.1",
           "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-5.1.1.tgz",
@@ -15145,6 +16082,12 @@
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true
         },
         "resolve": {
@@ -15732,7 +16675,6 @@
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
       "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
-      "dev": true,
       "requires": {
         "once": "^1.4.0"
       }
@@ -15848,7 +16790,8 @@
     "errlop": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/errlop/-/errlop-2.2.0.tgz",
-      "integrity": "sha512-e64Qj9+4aZzjzzFpZC7p5kmm/ccCrbLhAJplhsDXQFs87XTsXwOpH4s1Io2s90Tau/8r2j9f4l/thhDevRjzxw=="
+      "integrity": "sha512-e64Qj9+4aZzjzzFpZC7p5kmm/ccCrbLhAJplhsDXQFs87XTsXwOpH4s1Io2s90Tau/8r2j9f4l/thhDevRjzxw==",
+      "dev": true
     },
     "errno": {
       "version": "0.1.7",
@@ -16066,6 +17009,12 @@
             "estraverse": "^4.1.1"
           }
         },
+        "eslint-visitor-keys": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+          "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+          "dev": true
+        },
         "globals": {
           "version": "12.4.0",
           "resolved": "https://registry.npmjs.org/globals/-/globals-12.4.0.tgz",
@@ -16204,14 +17153,6 @@
         "ember-rfc176-data": "^0.3.15",
         "lodash.kebabcase": "^4.1.1",
         "snake-case": "^3.0.3"
-      },
-      "dependencies": {
-        "ember-rfc176-data": {
-          "version": "0.3.15",
-          "resolved": "https://registry.npmjs.org/ember-rfc176-data/-/ember-rfc176-data-0.3.15.tgz",
-          "integrity": "sha512-GPKa7zRDBblRy0orxTXt5yrpp/Pf5CkuRFSIR8qMFDww0CqCKjCRwdZnWYzCM4kAEfZnXRIDDefe1tBaFw7v7w==",
-          "dev": true
-        }
       }
     },
     "eslint-plugin-es": {
@@ -16266,9 +17207,9 @@
       }
     },
     "eslint-visitor-keys": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
-      "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz",
+      "integrity": "sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A==",
       "dev": true
     },
     "esm": {
@@ -16292,6 +17233,12 @@
           "version": "7.4.0",
           "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.0.tgz",
           "integrity": "sha512-+G7P8jJmCHr+S+cLfQxygbWhXy+8YTVGzAkpEbcLo2mLoL7tij/VG41QSHACSf5QgYRhMZYHuNc6drJaO0Da+w==",
+          "dev": true
+        },
+        "eslint-visitor-keys": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+          "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
           "dev": true
         }
       }
@@ -16393,6 +17340,12 @@
         "signal-exit": "^3.0.0",
         "strip-eof": "^1.0.0"
       }
+    },
+    "exists-sync": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/exists-sync/-/exists-sync-0.0.4.tgz",
+      "integrity": "sha1-l0TCxCjMA7AQYNtFTUsS8O88iHk=",
+      "dev": true
     },
     "exit": {
       "version": "0.1.2",
@@ -16547,28 +17500,6 @@
         }
       }
     },
-    "external-editor": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
-      "integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
-      "dev": true,
-      "requires": {
-        "chardet": "^0.7.0",
-        "iconv-lite": "^0.4.24",
-        "tmp": "^0.0.33"
-      },
-      "dependencies": {
-        "tmp": {
-          "version": "0.0.33",
-          "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-          "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-          "dev": true,
-          "requires": {
-            "os-tmpdir": "~1.0.2"
-          }
-        }
-      }
-    },
     "extglob": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
@@ -16641,23 +17572,22 @@
       "dev": true
     },
     "fast-deep-equal": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
+      "integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA==",
       "dev": true
     },
     "fast-glob": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.4.tgz",
-      "integrity": "sha512-kr/Oo6PX51265qeuCYsyGypiO5uJFgBS0jksyG7FUeCyQzNwYnzrNIMR1NXfkZXsMYXYLRAHgISHBz8gQcxKHQ==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.1.1.tgz",
+      "integrity": "sha512-nTCREpBY8w8r+boyFYAx21iL6faSsQynliPHM4Uf56SbkyohCNxpVPEH9xrF5TXKy+IsjkPUHDKiUkzBVRXn9g==",
       "dev": true,
       "requires": {
         "@nodelib/fs.stat": "^2.0.2",
         "@nodelib/fs.walk": "^1.2.3",
         "glob-parent": "^5.1.0",
         "merge2": "^1.3.0",
-        "micromatch": "^4.0.2",
-        "picomatch": "^2.2.1"
+        "micromatch": "^4.0.2"
       },
       "dependencies": {
         "braces": {
@@ -16769,6 +17699,213 @@
         }
       }
     },
+    "fastboot": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/fastboot/-/fastboot-2.0.3.tgz",
+      "integrity": "sha512-NNH/o+XhITAQUnW2CC9IDXlcnI74W2BONjtRSRmc01N3uJl/7pcvX9iWTUWu2PYQbQZUBu8HzVFt7GmQ9qw9JQ==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.0.1",
+        "cookie": "^0.4.0",
+        "debug": "^4.1.0",
+        "najax": "^1.0.3",
+        "resolve": "^1.8.1",
+        "rsvp": "^4.8.0",
+        "simple-dom": "^1.4.0",
+        "source-map-support": "^0.5.0"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        },
+        "source-map-support": {
+          "version": "0.5.19",
+          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
+          "integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
+          "dev": true,
+          "requires": {
+            "buffer-from": "^1.0.0",
+            "source-map": "^0.6.0"
+          }
+        }
+      }
+    },
+    "fastboot-express-middleware": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fastboot-express-middleware/-/fastboot-express-middleware-2.0.0.tgz",
+      "integrity": "sha512-sJHZrHpo/8jh56t+DTzaDcg6cnHbmXlTSAdfhRZbBa8XDY3TfN+TjHsHd4Z7vouLFU+ISuaZkzKfwGwipW5xwQ==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.0.1",
+        "fastboot": "^2.0.1",
+        "request": "^2.81.0"
+      }
+    },
+    "fastboot-transform": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/fastboot-transform/-/fastboot-transform-0.1.3.tgz",
+      "integrity": "sha512-6otygPIJw1ARp1jJb+6KVO56iKBjhO+5x59RSC9qiZTbZRrv+HZAuP00KD3s+nWMvcFDemtdkugki9DNFTTwCQ==",
+      "dev": true,
+      "requires": {
+        "broccoli-stew": "^1.5.0",
+        "convert-source-map": "^1.5.1"
+      },
+      "dependencies": {
+        "broccoli-funnel": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-2.0.2.tgz",
+          "integrity": "sha512-/vDTqtv7ipjEZQOVqO4vGDVAOZyuYzQ/EgGoyewfOgh1M7IQAToBKZI0oAQPgMBeFPPlIbfMuAngk+ohPBuaHQ==",
+          "dev": true,
+          "requires": {
+            "array-equal": "^1.0.0",
+            "blank-object": "^1.0.1",
+            "broccoli-plugin": "^1.3.0",
+            "debug": "^2.2.0",
+            "fast-ordered-set": "^1.0.0",
+            "fs-tree-diff": "^0.5.3",
+            "heimdalljs": "^0.2.0",
+            "minimatch": "^3.0.0",
+            "mkdirp": "^0.5.0",
+            "path-posix": "^1.0.0",
+            "rimraf": "^2.4.3",
+            "symlink-or-copy": "^1.0.0",
+            "walk-sync": "^0.3.1"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "2.6.9",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+              "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+              "dev": true,
+              "requires": {
+                "ms": "2.0.0"
+              }
+            }
+          }
+        },
+        "broccoli-merge-trees": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/broccoli-merge-trees/-/broccoli-merge-trees-2.0.1.tgz",
+          "integrity": "sha512-WjaexJ+I8BxP5V5RNn6um/qDRSmKoiBC/QkRi79FT9ClHfldxRyCDs9mcV7mmoaPlsshmmPaUz5jdtcKA6DClQ==",
+          "dev": true,
+          "requires": {
+            "broccoli-plugin": "^1.3.0",
+            "merge-trees": "^1.0.1"
+          }
+        },
+        "broccoli-persistent-filter": {
+          "version": "1.4.6",
+          "resolved": "https://registry.npmjs.org/broccoli-persistent-filter/-/broccoli-persistent-filter-1.4.6.tgz",
+          "integrity": "sha512-0RejLwoC95kv4kta8KAa+FmECJCK78Qgm8SRDEK7YyU0N9Cx6KpY3UCDy9WELl3mCXLN8TokNxc7/hp3lL4lfw==",
+          "dev": true,
+          "requires": {
+            "async-disk-cache": "^1.2.1",
+            "async-promise-queue": "^1.0.3",
+            "broccoli-plugin": "^1.0.0",
+            "fs-tree-diff": "^0.5.2",
+            "hash-for-dep": "^1.0.2",
+            "heimdalljs": "^0.2.1",
+            "heimdalljs-logger": "^0.1.7",
+            "mkdirp": "^0.5.1",
+            "promise-map-series": "^0.2.1",
+            "rimraf": "^2.6.1",
+            "rsvp": "^3.0.18",
+            "symlink-or-copy": "^1.0.1",
+            "walk-sync": "^0.3.1"
+          },
+          "dependencies": {
+            "rsvp": {
+              "version": "3.6.2",
+              "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz",
+              "integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw==",
+              "dev": true
+            }
+          }
+        },
+        "broccoli-stew": {
+          "version": "1.6.0",
+          "resolved": "https://registry.npmjs.org/broccoli-stew/-/broccoli-stew-1.6.0.tgz",
+          "integrity": "sha512-sUwCJNnYH4Na690By5xcEMAZqKgquUQnMAEuIiL3Z2k63mSw9Xg+7Ew4wCrFrMmXMcLpWjZDOm6Yqnq268N+ZQ==",
+          "dev": true,
+          "requires": {
+            "broccoli-debug": "^0.6.1",
+            "broccoli-funnel": "^2.0.0",
+            "broccoli-merge-trees": "^2.0.0",
+            "broccoli-persistent-filter": "^1.1.6",
+            "broccoli-plugin": "^1.3.0",
+            "chalk": "^2.4.1",
+            "debug": "^3.1.0",
+            "ensure-posix-path": "^1.0.1",
+            "fs-extra": "^5.0.0",
+            "minimatch": "^3.0.4",
+            "resolve": "^1.8.1",
+            "rsvp": "^4.8.3",
+            "symlink-or-copy": "^1.2.0",
+            "walk-sync": "^0.3.0"
+          }
+        },
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          },
+          "dependencies": {
+            "ms": {
+              "version": "2.1.2",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+              "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+              "dev": true
+            }
+          }
+        },
+        "fs-extra": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-5.0.0.tgz",
+          "integrity": "sha512-66Pm4RYbjzdyeuqudYqhFiNBbCIuI9kgRqLPSHIlXHidW8NIQtVdkM1yeZ4lXwuhbTETv3EUGMNHAAw6hiundQ==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "jsonfile": "^4.0.0",
+            "universalify": "^0.1.0"
+          }
+        },
+        "merge-trees": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/merge-trees/-/merge-trees-1.0.1.tgz",
+          "integrity": "sha1-zL5nRWl4f53vF/1G5lJfVwC70j4=",
+          "dev": true,
+          "requires": {
+            "can-symlink": "^1.0.0",
+            "fs-tree-diff": "^0.5.4",
+            "heimdalljs": "^0.2.1",
+            "heimdalljs-logger": "^0.1.7",
+            "rimraf": "^2.4.3",
+            "symlink-or-copy": "^1.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        },
+        "rimraf": {
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        }
+      }
+    },
     "fastq": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.8.0.tgz",
@@ -16806,7 +17943,6 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
       "integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
-      "dev": true,
       "requires": {
         "escape-string-regexp": "^1.0.5"
       }
@@ -16923,6 +18059,24 @@
         "commondir": "^1.0.1",
         "make-dir": "^2.0.0",
         "pkg-dir": "^3.0.0"
+      },
+      "dependencies": {
+        "make-dir": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
+          "integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
+          "dev": true,
+          "requires": {
+            "pify": "^4.0.1",
+            "semver": "^5.6.0"
+          }
+        },
+        "pify": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+          "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+          "dev": true
+        }
       }
     },
     "find-index": {
@@ -17041,9 +18195,9 @@
       }
     },
     "fixturify": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/fixturify/-/fixturify-1.2.0.tgz",
-      "integrity": "sha512-b5CMQmBZKsGR6HGqdSrLOGYGHIqrR0CUrcGU/lDL0mYy+DtGm5cnb61Z0UiIUqMVZIoV0CbN+u9/Gwjj+ICg0A==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fixturify/-/fixturify-1.3.0.tgz",
+      "integrity": "sha512-tL0svlOy56pIMMUQ4bU1xRe6NZbFSa/ABTWMxW2mH38lFGc9TrNAKWcMBQ7eIjo3wqSS8f2ICabFaatFyFmrVQ==",
       "requires": {
         "@types/fs-extra": "^5.0.5",
         "@types/minimatch": "^3.0.3",
@@ -17255,6 +18409,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/fs-merger/-/fs-merger-3.1.0.tgz",
       "integrity": "sha512-RZ9JtqugaE8Rkt7idO5NSwcxEGSDZpLmVFjtVQUm3f+bWun7JAU6fKyU6ZJUeUnKdJwGx8uaro+K4QQfOR7vpA==",
+      "dev": true,
       "requires": {
         "broccoli-node-api": "^1.7.0",
         "broccoli-node-info": "^2.1.0",
@@ -17267,12 +18422,14 @@
         "broccoli-node-info": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/broccoli-node-info/-/broccoli-node-info-2.1.0.tgz",
-          "integrity": "sha512-l6qDuboJThHfRVVWQVaTs++bFdrFTP0gJXgsWenczc1PavRVUmL1Eyb2swTAXXMpDOnr2zhNOBLx4w9AxkqbPQ=="
+          "integrity": "sha512-l6qDuboJThHfRVVWQVaTs++bFdrFTP0gJXgsWenczc1PavRVUmL1Eyb2swTAXXMpDOnr2zhNOBLx4w9AxkqbPQ==",
+          "dev": true
         },
         "fs-extra": {
           "version": "8.1.0",
           "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
           "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+          "dev": true,
           "requires": {
             "graceful-fs": "^4.2.0",
             "jsonfile": "^4.0.0",
@@ -17283,6 +18440,7 @@
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/fs-tree-diff/-/fs-tree-diff-2.0.1.tgz",
           "integrity": "sha512-x+CfAZ/lJHQqwlD64pYM5QxWjzWhSjroaVsr8PW831zOApL55qPibed0c+xebaLWVr2BnHFoHdrwOv8pzt8R5A==",
+          "dev": true,
           "requires": {
             "@types/symlink-or-copy": "^1.2.0",
             "heimdalljs-logger": "^0.1.7",
@@ -17295,6 +18453,7 @@
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/matcher-collection/-/matcher-collection-2.0.1.tgz",
           "integrity": "sha512-daE62nS2ZQsDg9raM0IlZzLmI2u+7ZapXBwdoeBUKAYERPDDIc0qNqA8E0Rp2D+gspKR7BgIFP52GeujaGXWeQ==",
+          "dev": true,
           "requires": {
             "@types/minimatch": "^3.0.3",
             "minimatch": "^3.0.2"
@@ -17304,18 +18463,21 @@
           "version": "2.7.1",
           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
           "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+          "dev": true,
           "requires": {
             "glob": "^7.1.3"
           }
         },
         "walk-sync": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-2.1.0.tgz",
-          "integrity": "sha512-KpH9Xw64LNSx7/UI+3guRZvJWlDxVA4+KKb/4puRoVrG8GkvZRxnF3vhxdjgpoKJGL2TVg1OrtkXIE/VuGPLHQ==",
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-2.2.0.tgz",
+          "integrity": "sha512-IC8sL7aB4/ZgFcGI2T1LczZeFWZ06b3zoHH7jBPyHxOtIIz1jppWHjjEXkOFvFojBVAK9pV7g47xOZ4LW3QLfg==",
+          "dev": true,
           "requires": {
             "@types/minimatch": "^3.0.3",
             "ensure-posix-path": "^1.1.0",
-            "matcher-collection": "^2.0.0"
+            "matcher-collection": "^2.0.0",
+            "minimatch": "^3.0.4"
           }
         }
       }
@@ -18375,6 +19537,20 @@
       "requires": {
         "ajv": "^6.12.3",
         "har-schema": "^2.0.0"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "6.12.4",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.4.tgz",
+          "integrity": "sha512-eienB2c9qVQs2KWexhkrdMLVDoIQCz5KSeLxwg9Lzk4DOfBtIK9PQwwufcsn1jjGuf9WZmqPMbGxOzfcuphJCQ==",
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
+          }
+        }
       }
     },
     "hard-rejection": {
@@ -18776,8 +19952,7 @@
     "human-signals": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz",
-      "integrity": "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==",
-      "dev": true
+      "integrity": "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw=="
     },
     "humanize-ms": {
       "version": "1.2.1",
@@ -18792,7 +19967,6 @@
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
       "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-      "dev": true,
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3"
       }
@@ -18983,6 +20157,12 @@
             "supports-color": "^7.1.0"
           }
         },
+        "chardet": {
+          "version": "0.7.0",
+          "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
+          "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
+          "dev": true
+        },
         "cli-width": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-3.0.0.tgz",
@@ -19009,6 +20189,17 @@
           "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
           "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
           "dev": true
+        },
+        "external-editor": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
+          "integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
+          "dev": true,
+          "requires": {
+            "chardet": "^0.7.0",
+            "iconv-lite": "^0.4.24",
+            "tmp": "^0.0.33"
+          }
         },
         "has-flag": {
           "version": "4.0.0",
@@ -19071,6 +20262,15 @@
           "requires": {
             "has-flag": "^4.0.0"
           }
+        },
+        "tmp": {
+          "version": "0.0.33",
+          "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+          "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+          "dev": true,
+          "requires": {
+            "os-tmpdir": "~1.0.2"
+          }
         }
       }
     },
@@ -19102,6 +20302,12 @@
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
       "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=",
+      "dev": true
+    },
+    "ip-regex": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-2.1.0.tgz",
+      "integrity": "sha1-+ni/XS5pE8kRzp+BnuUUa7bYROk=",
       "dev": true
     },
     "ipaddr.js": {
@@ -19220,8 +20426,7 @@
     "is-extendable": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-      "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
-      "dev": true
+      "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik="
     },
     "is-extglob": {
       "version": "2.1.1",
@@ -19333,11 +20538,16 @@
         "isobject": "^3.0.1"
       }
     },
+    "is-potential-custom-element-name": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.0.tgz",
+      "integrity": "sha1-DFLlS8yjkbssSUsh6GJtczbG45c=",
+      "dev": true
+    },
     "is-promise": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
-      "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
-      "dev": true
+      "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o="
     },
     "is-redirect": {
       "version": "1.0.0",
@@ -19444,8 +20654,7 @@
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
-      "dev": true
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
     },
     "isobject": {
       "version": "3.0.1",
@@ -19605,6 +20814,12 @@
       "integrity": "sha512-XwIBPqcMn57FxfT+Go5pzySnm4KWkT1Tv7gjrpT1srtf8Weynl6R273VJ5GjkRb51IzMp5nbaPjJXMWeju2MKg==",
       "dev": true
     },
+    "jquery-deferred": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/jquery-deferred/-/jquery-deferred-0.3.1.tgz",
+      "integrity": "sha1-WW7KHKr/VPYbEQlisjyv6nTDU1U=",
+      "dev": true
+    },
     "js-reporters": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/js-reporters/-/js-reporters-1.2.1.tgz",
@@ -19669,6 +20884,17 @@
         "whatwg-url": "^7.0.0",
         "ws": "^6.1.0",
         "xml-name-validator": "^3.0.0"
+      },
+      "dependencies": {
+        "ws": {
+          "version": "6.2.1",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.1.tgz",
+          "integrity": "sha512-GIyAXC2cB7LjvpgMt9EKS2ldqr0MTrORaleiOno6TweZ6r3TKtoFQWay/2PceJ3RuBasOHzXNn5Lrw1X0bEjqA==",
+          "dev": true,
+          "requires": {
+            "async-limiter": "~1.0.0"
+          }
+        }
       }
     },
     "jsesc": {
@@ -19680,6 +20906,12 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.0.tgz",
       "integrity": "sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg=",
+      "dev": true
+    },
+    "json-fn": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/json-fn/-/json-fn-1.1.1.tgz",
+      "integrity": "sha1-QpPJGYpILWaX0zSm4yzQ0iESHoA=",
       "dev": true
     },
     "json-parse-better-errors": {
@@ -20522,6 +21754,21 @@
         "minimatch": "^3.0.2"
       }
     },
+    "md5-hex": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/md5-hex/-/md5-hex-2.0.0.tgz",
+      "integrity": "sha1-0FiOnxx0lUSS7NJKwKxs6ZfZLjM=",
+      "dev": true,
+      "requires": {
+        "md5-o-matic": "^0.1.1"
+      }
+    },
+    "md5-o-matic": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/md5-o-matic/-/md5-o-matic-0.1.1.tgz",
+      "integrity": "sha1-givM1l4RfFFPqxdrJZRdVBAKA8M=",
+      "dev": true
+    },
     "md5.js": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
@@ -20744,8 +21991,7 @@
     "merge-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
-      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
-      "dev": true
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w=="
     },
     "merge-trees": {
       "version": "2.0.0",
@@ -20831,8 +22077,7 @@
     "mimic-fn": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
-      "dev": true
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="
     },
     "mimic-response": {
       "version": "1.0.1",
@@ -21285,6 +22530,17 @@
       "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
       "dev": true
     },
+    "najax": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/najax/-/najax-1.0.4.tgz",
+      "integrity": "sha512-wsSacA+RkgY1wxRxXCT3tdqzmamEv9PLeoV/ub9SlLf2RngbPMSqc3A7H35XJDfURC0twMmZsnPdsYPkuuFSVg==",
+      "dev": true,
+      "requires": {
+        "jquery-deferred": "^0.3.0",
+        "lodash.defaultsdeep": "^4.6.0",
+        "qs": "^6.2.0"
+      }
+    },
     "nan": {
       "version": "2.14.1",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.1.tgz",
@@ -21343,6 +22599,18 @@
       "requires": {
         "lower-case": "^2.0.1",
         "tslib": "^1.10.0"
+      }
+    },
+    "nock": {
+      "version": "12.0.3",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-12.0.3.tgz",
+      "integrity": "sha512-QNb/j8kbFnKCiyqi9C5DD0jH/FubFGj5rt9NQFONXwQm3IPB0CULECg/eS3AU1KgZb/6SwUa4/DTRKhVxkGABw==",
+      "dev": true,
+      "requires": {
+        "debug": "^4.1.0",
+        "json-stringify-safe": "^5.0.1",
+        "lodash": "^4.17.13",
+        "propagate": "^2.0.0"
       }
     },
     "node-dir": {
@@ -21507,8 +22775,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "normalize-url": {
       "version": "2.0.1",
@@ -25847,12 +27114,20 @@
       }
     },
     "onetime": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
-      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
+      "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
       "dev": true,
       "requires": {
-        "mimic-fn": "^2.1.0"
+        "mimic-fn": "^1.0.0"
+      },
+      "dependencies": {
+        "mimic-fn": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
+          "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
+          "dev": true
+        }
       }
     },
     "open": {
@@ -25934,31 +27209,6 @@
             "restore-cursor": "^2.0.0"
           }
         },
-        "mimic-fn": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
-          "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
-          "dev": true
-        },
-        "onetime": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
-          "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
-          "dev": true,
-          "requires": {
-            "mimic-fn": "^1.0.0"
-          }
-        },
-        "restore-cursor": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
-          "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
-          "dev": true,
-          "requires": {
-            "onetime": "^2.0.0",
-            "signal-exit": "^3.0.2"
-          }
-        },
         "strip-ansi": {
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
@@ -25990,7 +27240,6 @@
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
       "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
-      "dev": true,
       "requires": {
         "os-homedir": "^1.0.0",
         "os-tmpdir": "^1.0.0"
@@ -26679,6 +27928,12 @@
       "integrity": "sha512-0qhWYyCV9TYDMSooYw1fShIb7R6hsWYja7JLqbeb1MvHqDTvP/uy/R1RsyVqDi6GCiHOI4G5p2Hpr3IA+/l/+Q==",
       "dev": true
     },
+    "propagate": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/propagate/-/propagate-2.0.1.tgz",
+      "integrity": "sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==",
+      "dev": true
+    },
     "proxy-addr": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.6.tgz",
@@ -26727,7 +27982,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
       "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
-      "dev": true,
       "requires": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
@@ -27098,17 +28352,9 @@
       }
     },
     "regenerator-runtime": {
-      "version": "0.13.3",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
-      "integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw=="
-    },
-    "regenerator-transform": {
-      "version": "0.14.5",
-      "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.14.5.tgz",
-      "integrity": "sha512-eOf6vka5IO151Jfsw2NO9WpGX58W6wWmefK3I1zEGr0lOD0u8rwPaNqQL1aRxUaxLeKO3ArNh3VYg1KbaD+FFw==",
-      "requires": {
-        "@babel/runtime": "^7.8.4"
-      }
+      "version": "0.13.7",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
+      "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
     },
     "regex-not": {
       "version": "1.0.2",
@@ -27360,12 +28606,12 @@
       }
     },
     "restore-cursor": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
-      "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
+      "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
       "dev": true,
       "requires": {
-        "onetime": "^5.1.0",
+        "onetime": "^2.0.0",
         "signal-exit": "^3.0.2"
       }
     },
@@ -27404,9 +28650,9 @@
       }
     },
     "rimraf": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.1.tgz",
-      "integrity": "sha512-IQ4ikL8SjBiEDZfk+DFVwqRK8md24RWMEJkdSlgNLkyyAImcjf8SWvU1qFMDOb4igBClbTQ/ugPqXcRwdFTxZw==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
       "requires": {
         "glob": "^7.1.3"
       }
@@ -27430,7 +28676,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
       "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
-      "dev": true,
       "requires": {
         "is-promise": "^2.1.0"
       }
@@ -27454,7 +28699,6 @@
       "version": "6.5.4",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.4.tgz",
       "integrity": "sha512-naMQXcgEo3csAEGvw/NydRA0fuS2nDZJiw1YUWFKU7aPPAPGZEsD4Iimit96qwCieH6y614MCLYwdkrWx7z/7Q==",
-      "dev": true,
       "requires": {
         "tslib": "^1.9.0"
       }
@@ -27482,8 +28726,7 @@
     "safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "sane": {
       "version": "4.1.0",
@@ -27556,6 +28799,20 @@
         "@types/json-schema": "^7.0.4",
         "ajv": "^6.12.2",
         "ajv-keywords": "^3.4.1"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "6.12.4",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.4.tgz",
+          "integrity": "sha512-eienB2c9qVQs2KWexhkrdMLVDoIQCz5KSeLxwg9Lzk4DOfBtIK9PQwwufcsn1jjGuf9WZmqPMbGxOzfcuphJCQ==",
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
+          }
+        }
       }
     },
     "semver": {
@@ -27758,8 +29015,7 @@
     "signal-exit": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
-      "dev": true
+      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
     },
     "silent-error": {
       "version": "1.1.1",
@@ -27782,6 +29038,19 @@
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         }
+      }
+    },
+    "simple-dom": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/simple-dom/-/simple-dom-1.4.0.tgz",
+      "integrity": "sha512-TnBPkmOyjdaOqyBMb4ick+n8c0Xv9Iwg1PykFV7hz9Se3UCiacTbRb+25cPmvozFNJLBUNvUzX/KsPfXF14ivA==",
+      "dev": true,
+      "requires": {
+        "@simple-dom/document": "^1.4.0",
+        "@simple-dom/interface": "^1.4.0",
+        "@simple-dom/parser": "^1.4.0",
+        "@simple-dom/serializer": "^1.4.0",
+        "@simple-dom/void-map": "^1.4.0"
       }
     },
     "simple-html-tokenizer": {
@@ -28682,8 +29951,7 @@
     "strip-final-newline": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
-      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
-      "dev": true
+      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA=="
     },
     "strip-indent": {
       "version": "3.0.0",
@@ -28901,35 +30169,6 @@
       "integrity": "sha512-a6sumDlzyHVJWb8+YofY4TW112G6p2FCPEAFk+59gIYHv3XHRhm9ltVQ9kli4hNWeQBwSpe8cRN25x0ROunMOw==",
       "dev": true
     },
-    "terser": {
-      "version": "4.8.0",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-4.8.0.tgz",
-      "integrity": "sha512-EAPipTNeWsb/3wLPeup1tVPaXfIaU68xMnVdPafIL1TV05OhASArYyIfFvnvJCNrR2NIOvDVNNTFRa+Re2MWyw==",
-      "dev": true,
-      "requires": {
-        "commander": "^2.20.0",
-        "source-map": "~0.6.1",
-        "source-map-support": "~0.5.12"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true
-        },
-        "source-map-support": {
-          "version": "0.5.19",
-          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
-          "integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
-          "dev": true,
-          "requires": {
-            "buffer-from": "^1.0.0",
-            "source-map": "^0.6.0"
-          }
-        }
-      }
-    },
     "terser-webpack-plugin": {
       "version": "1.4.5",
       "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.4.5.tgz",
@@ -28996,6 +30235,16 @@
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
           "dev": true
         },
+        "source-map-support": {
+          "version": "0.5.19",
+          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
+          "integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
+          "dev": true,
+          "requires": {
+            "buffer-from": "^1.0.0",
+            "source-map": "^0.6.0"
+          }
+        },
         "ssri": {
           "version": "6.0.1",
           "resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.1.tgz",
@@ -29003,6 +30252,17 @@
           "dev": true,
           "requires": {
             "figgy-pudding": "^3.5.1"
+          }
+        },
+        "terser": {
+          "version": "4.8.0",
+          "resolved": "https://registry.npmjs.org/terser/-/terser-4.8.0.tgz",
+          "integrity": "sha512-EAPipTNeWsb/3wLPeup1tVPaXfIaU68xMnVdPafIL1TV05OhASArYyIfFvnvJCNrR2NIOvDVNNTFRa+Re2MWyw==",
+          "dev": true,
+          "requires": {
+            "commander": "^2.20.0",
+            "source-map": "~0.6.1",
+            "source-map-support": "~0.5.12"
           }
         }
       }
@@ -29168,22 +30428,22 @@
     "through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
-      "dev": true
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
     },
     "through2": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/through2/-/through2-3.0.1.tgz",
-      "integrity": "sha512-M96dvTalPT3YbYLaKaCuwu+j06D/8Jfib0o/PxbVt6Amhv3dUAtW6rTV1jPgJSBG83I/e04Y6xkVdVhSRhi0ww==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-3.0.2.tgz",
+      "integrity": "sha512-enaDQ4MUyP2W6ZyT6EsMzqBPZaM/avg8iuo+l2d3QCs0J+6RaqkHV/2/lOwDTueBHeJ/2LG9lrLW3d5rWPucuQ==",
       "dev": true,
       "requires": {
+        "inherits": "^2.0.4",
         "readable-stream": "2 || 3"
       },
       "dependencies": {
         "readable-stream": {
-          "version": "3.5.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.5.0.tgz",
-          "integrity": "sha512-gSz026xs2LfxBPudDuI41V1lka8cxg64E66SGe78zJlsUofOg/yqwezdIcdfwik6B4h8LFmWPA9ef9X3FiNFLA==",
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
           "dev": true,
           "requires": {
             "inherits": "^2.0.3",
@@ -29192,9 +30452,9 @@
           }
         },
         "safe-buffer": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
-          "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg==",
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
           "dev": true
         },
         "string_decoder": {
@@ -29405,8 +30665,7 @@
     "tslib": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
-      "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==",
-      "dev": true
+      "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ=="
     },
     "tty-browserify": {
       "version": "0.0.0",
@@ -29441,8 +30700,7 @@
     "type-fest": {
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
-      "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
-      "dev": true
+      "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA=="
     },
     "type-is": {
       "version": "1.6.18",
@@ -29579,15 +30837,6 @@
       "dev": true,
       "requires": {
         "imurmurhash": "^0.1.4"
-      }
-    },
-    "unique-string": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-2.0.0.tgz",
-      "integrity": "sha512-uNaeirEPvpZWSgzwsPGtU2zVSTrn/8L5q/IexZmH0eH6SA73CmAA5U4GwORTxQAZs95TAXLNqeLoPPNO5gZfWg==",
-      "dev": true,
-      "requires": {
-        "crypto-random-string": "^2.0.0"
       }
     },
     "universalify": {
@@ -29943,7 +31192,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-3.0.0.tgz",
       "integrity": "sha1-X6kS2B630MdK/BQN5zF/DKffQ34=",
-      "dev": true,
       "requires": {
         "builtins": "^1.0.3"
       }
@@ -29978,6 +31226,15 @@
       "dev": true,
       "requires": {
         "browser-process-hrtime": "^1.0.0"
+      }
+    },
+    "w3c-xmlserializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-2.0.0.tgz",
+      "integrity": "sha512-4tzD0mF8iSiMiNs30BiLO3EpfGLZUT2MSX/G+o7ZywDzliWQ3OPtTZ0PTC3B3ca1UAf4cJMHB+2Bf56EriJuRA==",
+      "dev": true,
+      "requires": {
+        "xml-name-validator": "^3.0.0"
       }
     },
     "walk-sync": {
@@ -30048,6 +31305,17 @@
         "watchpack-chokidar2": "^2.0.0"
       },
       "dependencies": {
+        "anymatch": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
+          "integrity": "sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "normalize-path": "^3.0.0",
+            "picomatch": "^2.0.4"
+          }
+        },
         "braces": {
           "version": "3.0.2",
           "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
@@ -30085,10 +31353,27 @@
             "to-regex-range": "^5.0.1"
           }
         },
+        "is-glob": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
+          "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "is-extglob": "^2.1.1"
+          }
+        },
         "is-number": {
           "version": "7.0.0",
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
           "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+          "dev": true,
+          "optional": true
+        },
+        "normalize-path": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+          "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
           "dev": true,
           "optional": true
         },
@@ -30218,6 +31503,23 @@
           "requires": {
             "binary-extensions": "^1.0.0"
           }
+        },
+        "is-glob": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
+          "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "is-extglob": "^2.1.1"
+          }
+        },
+        "normalize-path": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+          "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+          "dev": true,
+          "optional": true
         },
         "readable-stream": {
           "version": "2.3.7",
@@ -30401,6 +31703,12 @@
       "requires": {
         "iconv-lite": "0.4.24"
       }
+    },
+    "whatwg-fetch": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.4.0.tgz",
+      "integrity": "sha512-rsum2ulz2iuZH08mJkT0Yi6JnKhwdw4oeyMjokgxd+mmqYSd9cPpOQf01TIWgjxG/U4+QR+AwKq6lSbXVxkyoQ==",
+      "dev": true
     },
     "whatwg-mimetype": {
       "version": "2.3.0",
@@ -30626,13 +31934,10 @@
       }
     },
     "ws": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.1.tgz",
-      "integrity": "sha512-GIyAXC2cB7LjvpgMt9EKS2ldqr0MTrORaleiOno6TweZ6r3TKtoFQWay/2PceJ3RuBasOHzXNn5Lrw1X0bEjqA==",
-      "dev": true,
-      "requires": {
-        "async-limiter": "~1.0.0"
-      }
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.3.1.tgz",
+      "integrity": "sha512-D3RuNkynyHmEJIpD2qrgVkc9DQ23OrN/moAwZX4L8DfvszsJxpjQuUq3LMx6HoYji9fbIOBY18XWBsAux1ZZUA==",
+      "dev": true
     },
     "xdg-basedir": {
       "version": "4.0.0",
@@ -30679,8 +31984,7 @@
     "yallist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-      "dev": true
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
     },
     "yam": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -28,8 +28,6 @@
   },
   "dependencies": {
     "ember-cli-babel": "^7.21.0",
-    "ember-cli-head": "^1.0.0",
-    "ember-cli-htmlbars": "^5.2.0",
     "ember-copy": "^1.0.0"
   },
   "devDependencies": {
@@ -43,7 +41,10 @@
     "ember-cli": "~3.20.0",
     "ember-cli-code-coverage": "1.0.0-beta.8",
     "ember-cli-dependency-checker": "^3.2.0",
+    "ember-cli-fastboot": "^2.2.3",
+    "ember-cli-fastboot-testing": "^0.4.0",
     "ember-cli-github-pages": "^0.2.0",
+    "ember-cli-htmlbars": "^5.2.0",
     "ember-cli-inject-live-reload": "^2.0.2",
     "ember-cli-sass": "^10.0.1",
     "ember-cli-uglify": "^3.0.0",

--- a/tests/acceptance/posts-test.js
+++ b/tests/acceptance/posts-test.js
@@ -1,95 +1,89 @@
 import { click, find, waitUntil, visit } from '@ember/test-helpers';
 import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
+import { getPageTitle } from '../helpers/get-page-title';
 
 module('Acceptance: title', function(hooks) {
   setupApplicationTest(hooks);
-
-  // Testem appends progress to the title...
-  // and there's no way to stop this at the moment
-  function title() {
-    let element = document.querySelector('head title');
-    return element && element.innerText.trim().replace(/^\(\d+\/\d+\)/, '');
-  }
 
   test('the default configuration works', async function (assert) {
     assert.expect(1);
     await visit('/posts');
 
-    assert.equal(title(), 'Posts | My App');
+    assert.equal(getPageTitle(), 'Posts | My App');
   });
 
   test('the replace attribute works', async function (assert) {
     assert.expect(1);
     await visit('/about');
 
-    assert.equal(title(), 'About My App');
+    assert.equal(getPageTitle(), 'About My App');
   });
 
   test('custom separators work', async function (assert) {
     assert.expect(1);
     await visit('/about/authors');
 
-    assert.equal(title(), 'Authors > About My App');
+    assert.equal(getPageTitle(), 'Authors > About My App');
   });
 
   test('custom separators are inherited', async function (assert) {
     assert.expect(1);
     await visit('/about/authors/profile');
 
-    assert.equal(title(), 'Profile > Authors > About My App');
+    assert.equal(getPageTitle(), 'Profile > Authors > About My App');
   });
 
   test('multiple components in a row work', async function (assert) {
     assert.expect(1);
     await visit('/posts/rails-is-omakase');
 
-    assert.equal(title(), 'Rails is Omakase | Posts | My App');
+    assert.equal(getPageTitle(), 'Rails is Omakase | Posts | My App');
   });
 
   test('the prepend=false declaration works', async function (assert) {
     assert.expect(1);
     await visit('/authors/tomster');
 
-    assert.equal(title(), 'My App | Authors < Tomster');
+    assert.equal(getPageTitle(), 'My App | Authors < Tomster');
   });
 
   test('replace nested in prepends work', async function (assert) {
     assert.expect(1);
     await visit('/hollywood');
 
-    assert.equal(title(), 'Hollywood ★ Stars everywhere');
+    assert.equal(getPageTitle(), 'Hollywood ★ Stars everywhere');
   });
 
   test('multitoken titles work', async function (assert) {
     assert.expect(1);
     await visit('/feeds/tomster');
 
-    assert.equal(title(), 'Tomster (@tomster)');
+    assert.equal(getPageTitle(), 'Tomster (@tomster)');
   });
 
   test('loading substates are not shown', async function (assert) {
     assert.expect(3);
     await visit('/feeds/tomster');
-    assert.equal(title(), 'Tomster (@tomster)');
+    assert.equal(getPageTitle(), 'Tomster (@tomster)');
 
     await click('#zoey');
     await waitUntil(() => {
       return find('div[data-test-substate-loading]') === null;
     });
-    assert.equal(title(), 'Zoey (@zoey)');
+    assert.equal(getPageTitle(), 'Zoey (@zoey)');
 
     await click('#tomster');
     await waitUntil(() => {
       return find('div[data-test-substate-loading]') === null;
     });
-    assert.equal(title(), 'Tomster (@tomster)');
+    assert.equal(getPageTitle(), 'Tomster (@tomster)');
   });
 
   test('front tokens work', async function (assert) {
     assert.expect(1);
     await visit('/reader');
 
-    assert.equal(title(), '(10) Reader | My App');
+    assert.equal(getPageTitle(), '(10) Reader | My App');
   });
 });

--- a/tests/dummy/app/components/page-title-pane/component.js
+++ b/tests/dummy/app/components/page-title-pane/component.js
@@ -8,23 +8,18 @@ export default Component.extend({
 
   titleList: service(),
 
-  lastIndex: computed('titleList.{sortedTokens.length,tokens.length}', {
+  lastIndex: computed('titleList.{tokens.length}', {
     get() {
-      return this.titleList.sortedTokens.length - 1;
+      return this.titleList.tokens.length - 1;
     },
   }),
 
   actions: {
     highlight(token) {
-      let sortedTokens = A(this.titleList.sortedTokens);
+      let tokens = A(this.titleList.tokens);
       let wasActive = token.active;
-      this.titleList.tokens.setEach('active', false);
-      sortedTokens.setEach('active', false);
-
-      if (!wasActive) {
-        set(sortedTokens.findBy('id', token.id), 'active', true);
-        set(token, 'active', true);
-      }
+      tokens.setEach('active', false);
+      set(token, 'active', !wasActive);
     },
   },
 });

--- a/tests/dummy/app/components/page-title-pane/nested-template/component.js
+++ b/tests/dummy/app/components/page-title-pane/nested-template/component.js
@@ -7,10 +7,10 @@ export default Component.extend({
   classNames: ['nested-template'],
   classNameBindings: ['active:active'],
 
-  active: computed('titleList.{sortedTokens,tokens.@each.active}', 'token.id', {
+  active: computed('titleList.{tokens.@each.active}', 'token.id', {
     get() {
-      let sortedTokens = A(this.titleList.sortedTokens);
-      let token = sortedTokens.findBy('id', this.token.id);
+      let tokens = A(this.titleList.tokens);
+      let token = tokens.findBy('id', this.token.id);
       return token && token.active;
     },
   }),

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -1,5 +1,3 @@
-{{head-layout}}
-
 {{! template-lint-disable simple-unless }}
 {{#unless (equals this.router.currentRouteName "index")}}
   {{page-title "My App"}}

--- a/tests/fastboot/title-test.js
+++ b/tests/fastboot/title-test.js
@@ -1,0 +1,70 @@
+import { module, test } from 'qunit';
+import { setup, visit } from 'ember-cli-fastboot-testing/test-support';
+import { getPageTitle } from "../helpers/get-page-title"
+
+module('FastBoot: title', function(hooks) {
+  setup(hooks);
+
+  test('the default configuration works', async function (assert) {
+    assert.expect(1);
+    let { htmlDocument } = await visit('/posts');
+
+    assert.equal(getPageTitle(htmlDocument), 'Posts | My App');
+  });
+
+  test('the replace attribute works', async function (assert) {
+    assert.expect(1);
+    let { htmlDocument } = await visit('/about');
+
+    assert.equal(getPageTitle(htmlDocument), 'About My App');
+  });
+
+  test('custom separators work', async function (assert) {
+    assert.expect(1);
+    let { htmlDocument } = await visit('/about/authors');
+
+    assert.equal(getPageTitle(htmlDocument), 'Authors > About My App');
+  });
+
+  test('custom separators are inherited', async function (assert) {
+    assert.expect(1);
+    let { htmlDocument } = await visit('/about/authors/profile');
+
+    assert.equal(getPageTitle(htmlDocument), 'Profile > Authors > About My App');
+  });
+
+  test('multiple components in a row work', async function (assert) {
+    assert.expect(1);
+    let { htmlDocument } = await visit('/posts/rails-is-omakase');
+
+    assert.equal(getPageTitle(htmlDocument), 'Rails is Omakase | Posts | My App');
+  });
+
+  test('the prepend=false declaration works', async function (assert) {
+    assert.expect(1);
+    let { htmlDocument } = await visit('/authors/tomster');
+
+    assert.equal(getPageTitle(htmlDocument), 'My App | Authors < Tomster');
+  });
+
+  test('replace nested in prepends work', async function (assert) {
+    assert.expect(1);
+    let { htmlDocument } = await visit('/hollywood');
+
+    assert.equal(getPageTitle(htmlDocument), 'Hollywood ★ Stars everywhere');
+  });
+
+  test('multitoken titles work', async function (assert) {
+    assert.expect(1);
+    let { htmlDocument } = await visit('/feeds/tomster');
+
+    assert.equal(getPageTitle(htmlDocument), 'Tomster (@tomster)');
+  });
+
+  test('front tokens work', async function (assert) {
+    assert.expect(1);
+    let { htmlDocument } = await visit('/reader');
+
+    assert.equal(getPageTitle(htmlDocument), '(10) Reader | My App');
+  });
+});

--- a/tests/helpers/get-page-title.js
+++ b/tests/helpers/get-page-title.js
@@ -1,0 +1,10 @@
+// Testem appends progress to the title...
+// and there's no way to stop this at the moment
+
+export function getPageTitle(doc) {
+  // In Fastboot context we get 2 title elements if we don't remove one from app/index.html
+  // In real world applications, it is mandatory to remove <title> from app/index.html
+  // We are keeping both for sake for testing browser and fastboot scenarios
+  let element = [...(doc || window.document).querySelectorAll('head title')].pop();
+  return element && element.innerText.trim().replace(/^\(\d+\/\d+\)/, '');
+}

--- a/tests/unit/services/page-title-list-test.js
+++ b/tests/unit/services/page-title-list-test.js
@@ -5,13 +5,13 @@ module('service:page-title-list', function(hooks) {
   setupTest(hooks);
 
   test('the list has no tokens by default', function (assert) {
-    assert.equal(this.owner.lookup('service:page-title-list').length, 0);
+    assert.equal(this.owner.lookup('service:page-title-list').tokens.length, 0);
   });
 
   test('calling `push` adds a token to the end of the list', function (assert) {
     let list = this.owner.lookup('service:page-title-list');
     list.push({ id: 1});
-    assert.equal(list.length, 1);
+    assert.equal(list.tokens.length, 1);
   });
 
   test('tokens have next and previous tokens', function (assert) {
@@ -24,7 +24,7 @@ module('service:page-title-list', function(hooks) {
     list.push(second);
     list.push(third);
 
-    assert.equal(list.length, 3);
+    assert.equal(list.tokens.length, 3);
 
     assert.equal(first.previous, null);
     assert.equal(first.next, second);
@@ -46,7 +46,7 @@ module('service:page-title-list', function(hooks) {
     list.push(second);
     list.push(third);
     list.remove(2);
-    assert.equal(list.length, 2);
+    assert.equal(list.tokens.length, 2);
 
     assert.equal(first.previous, null);
     assert.equal(first.next, third);


### PR DESCRIPTION
Use direct page title manipulation instead of ember-cli-head.

Fastboot apps have to remove `<title>` from app/index.html as before and for non-fastboot apps everything should work out of the box.

Closes #167 