### PR TITLE
Clean up head.hbs being generated by blueprint

### DIFF
--- a/blueprints/ember-page-title/files/__root__/templates/head.hbs
+++ b/blueprints/ember-page-title/files/__root__/templates/head.hbs
@@ -1,6 +1,0 @@
-{{!--
-Add content you wish automatically added to the documents head
-here. The 'model' available in this template can be populated by
-setting values on the 'head-data' service.
---}}
-<title>{{model.title}}</title>

--- a/tests/dummy/app/templates/head.hbs
+++ b/tests/dummy/app/templates/head.hbs
@@ -1,1 +1,0 @@
-<title>{{model.title}}</title>


### PR DESCRIPTION
This is a follow up for #168 to clean up head.hbs being present in blueprint files.