### PR TITLE
Templates comply with Octane ember-template-lint rules

### DIFF
--- a/.template-lintrc.js
+++ b/.template-lintrc.js
@@ -1,5 +1,5 @@
 'use strict';
 
 module.exports = {
-  extends: 'recommended' // TODO migrate to "octane"
+  extends: 'octane'
 };

--- a/tests/dummy/app/components/boolean-field/template.hbs
+++ b/tests/dummy/app/components/boolean-field/template.hbs
@@ -1,1 +1,1 @@
-{{#if value}}true{{else}}false{{/if}}
+{{#if @value}}true{{else}}false{{/if}}

--- a/tests/dummy/app/components/page-title-pane/component.js
+++ b/tests/dummy/app/components/page-title-pane/component.js
@@ -1,25 +1,22 @@
 import { A } from '@ember/array';
-import Component from '@ember/component';
-import { computed, set } from '@ember/object';
+import Component from '@glimmer/component';
+import { computed, set, action } from '@ember/object';
 import { inject as service } from '@ember/service';
 
-export default Component.extend({
-  tagName: '',
+export default class PageTitlePaneComponent extends Component {
+  @service
+  titleList;
 
-  titleList: service(),
+  @computed('titleList.{tokens.length}')
+  get lastIndex() {
+    return this.titleList.tokens.length - 1;
+  }
 
-  lastIndex: computed('titleList.{tokens.length}', {
-    get() {
-      return this.titleList.tokens.length - 1;
-    },
-  }),
-
-  actions: {
-    highlight(token) {
-      let tokens = A(this.titleList.tokens);
-      let wasActive = token.active;
-      tokens.setEach('active', false);
-      set(token, 'active', !wasActive);
-    },
-  },
-});
+  @action
+  highlight(token) {
+    let tokens = A(this.titleList.tokens);
+    let wasActive = token.active;
+    tokens.setEach('active', false);
+    set(token, 'active', !wasActive);
+  }
+}

--- a/tests/dummy/app/components/page-title-pane/matryoshka/template.hbs
+++ b/tests/dummy/app/components/page-title-pane/matryoshka/template.hbs
@@ -1,8 +1,19 @@
-{{#page-title-pane/nested-template title=item.value replace=item.replace prepend=item.prepend separator=item.separator onactivate=onactivate titleList=titleList}}
-  {{yield item}}
-  {{#if nextItems.length}}
-    {{#page-title-pane/matryoshka componentName items=nextItems onactivate=onactivate titleList=titleList as |value|}}
+<PageTitlePane::NestedTemplate
+  @title={{this.item.value}}
+  @replace={{this.item.replace}}
+  @prepend={{this.item.prepend}}
+  @separator={{this.item.separator}}
+  @onactivate={{@onactivate}}
+  @titleList={{@titleList}}
+>
+  {{yield this.item}}
+  {{#if this.nextItems.length}}
+    <PageTitlePane::Matryoshka
+      @items={{this.nextItems}}
+      @onactivate={{@onactivate}}
+      @titleList={{@titleList}} as |value|
+    >
       {{yield value}}
-    {{/page-title-pane/matryoshka}}
+    </PageTitlePane::Matryoshka>
   {{/if}}
-{{/page-title-pane/nested-template}}
+</PageTitlePane::NestedTemplate>

--- a/tests/dummy/app/components/page-title-pane/template.hbs
+++ b/tests/dummy/app/components/page-title-pane/template.hbs
@@ -3,19 +3,19 @@
     <span class="close button"></span>
     <span class="minimize button"></span>
     <span class="maximize button"></span>
-    {{#each titleList.sortedTokens as |token idx|}}
+    {{#each this.titleList.sortedTokens as |token idx|}}
       <span
         role="button"
         class={{concat "title-token" " " (if token.active "active")}}
         onclick={{action "highlight" token}}>
         {{token.title}}
       </span>
-      {{#if (lt idx lastIndex)}}{{token.separator}}{{/if}}
+      {{#if (lt idx this.lastIndex)}}{{token.separator}}{{/if}}
     {{/each}}
   </header>
   <div>
     {{yield (hash
-      template=(component "page-title-pane/nested-template" titleList=titleList onactivate=(action "highlight"))
-      matryoshka=(component "page-title-pane/matryoshka" titleList=titleList onactivate=(action "highlight")))}}
+      template=(component "page-title-pane/nested-template" titleList=this.titleList onactivate=(action "highlight"))
+      matryoshka=(component "page-title-pane/matryoshka" titleList=this.titleList onactivate=(action "highlight")))}}
   </div>
 </div>

--- a/tests/dummy/app/components/page-title-pane/template.hbs
+++ b/tests/dummy/app/components/page-title-pane/template.hbs
@@ -7,7 +7,8 @@
       <span
         role="button"
         class={{concat "title-token" " " (if token.active "active")}}
-        onclick={{action "highlight" token}}>
+        {{on "click" (fn this.highlight token)}}
+      >
         {{token.title}}
       </span>
       {{#if (lt idx this.lastIndex)}}{{token.separator}}{{/if}}
@@ -15,7 +16,7 @@
   </header>
   <div>
     {{yield (hash
-      template=(component "page-title-pane/nested-template" titleList=this.titleList onactivate=(action "highlight"))
-      matryoshka=(component "page-title-pane/matryoshka" titleList=this.titleList onactivate=(action "highlight")))}}
+      template=(component "page-title-pane/nested-template" titleList=this.titleList onactivate=(fn this.highlight))
+      matryoshka=(component "page-title-pane/matryoshka" titleList=this.titleList onactivate=(fn this.highlight)))}}
   </div>
 </div>

--- a/tests/dummy/app/components/text-field/component.js
+++ b/tests/dummy/app/components/text-field/component.js
@@ -8,13 +8,13 @@ import Autoresize from 'ember-autoresize/mixins/autoresize';
 import layout from './template';
 
 /**
-  A `{{text-field}}` is a drop in replacement
+  A `<TextField />` is a drop in replacement
   for `<input type="text">`.
 
-  The simplest `{{text-field}}` would be:
+  The simplest `<TextField />` would be:
 
   ```htmlbars
-  {{text-field value=score onchange=(action (mut score))}}
+  <TextField @value={{this.score}} @onchange={{fn (mut this.score)}} />
   ```
 
   @public

--- a/tests/dummy/app/components/text-field/template.hbs
+++ b/tests/dummy/app/components/text-field/template.hbs
@@ -1,10 +1,10 @@
 <input type="text"
-       id={{inputId}}
-       name={{name}}
-       placeholder={{placeholder}}
+       id={{this.inputId}}
+       name={{this.name}}
+       placeholder={{this.placeholder}}
        autocomplete="off"
        onclick={{action "blackHole"}}
        onpaste={{action "reformat"}}
        onchange={{action "reformat"}}
        oninput={{action "reformat"}}
-       disabled={{disabled}}>
+       disabled={{this.disabled}}>

--- a/tests/dummy/app/components/text-field/template.hbs
+++ b/tests/dummy/app/components/text-field/template.hbs
@@ -1,10 +1,13 @@
+{{!template-lint-disable no-action}}
+{{!TODO fix actions when migrating to Glimmer component}}
 <input type="text"
-       id={{this.inputId}}
-       name={{this.name}}
-       placeholder={{this.placeholder}}
-       autocomplete="off"
-       onclick={{action "blackHole"}}
-       onpaste={{action "reformat"}}
-       onchange={{action "reformat"}}
-       oninput={{action "reformat"}}
-       disabled={{this.disabled}}>
+  id={{this.inputId}}
+  name={{this.name}}
+  placeholder={{this.placeholder}}
+  autocomplete="off"
+  {{on "click" (action "blackHole")}}
+  {{on "paste" (action "reformat")}}
+  {{on "change" (action "reformat")}}
+  {{on "input" (action "reformat")}}
+  disabled={{this.disabled}}
+/>

--- a/tests/dummy/app/components/window-pane/template.hbs
+++ b/tests/dummy/app/components/window-pane/template.hbs
@@ -1,9 +1,9 @@
-<div class={{concat "window-pane" (if title " has-title")}}>
+<div class={{concat "window-pane" (if @title " has-title")}}>
   <header>
     <span class="close button"></span>
     <span class="minimize button"></span>
     <span class="maximize button"></span>
-    {{title}}
+    {{@title}}
   </header>
   <div>
     {{yield this}}

--- a/tests/dummy/app/index/controller.js
+++ b/tests/dummy/app/index/controller.js
@@ -1,14 +1,13 @@
 import Controller from '@ember/controller';
-import { set } from '@ember/object';
+import { set, action } from '@ember/object';
 
-export default Controller.extend({
-  actions: {
-    add(tokens) {
-      let lastToken = tokens.slice(-1)[0];
-      set(this, 'model.tokens', tokens.concat({
-        separator: lastToken.separator,
-        prepend: lastToken.prepend
-      }));
-    }
+export default class IndexController extends Controller {
+  @action
+  add(tokens) {
+    let lastToken = tokens.slice(-1)[0];
+    set(this, 'model.tokens', tokens.concat({
+      separator: lastToken.separator,
+      prepend: lastToken.prepend
+    }));
   }
-});
+}

--- a/tests/dummy/app/index/template.hbs
+++ b/tests/dummy/app/index/template.hbs
@@ -31,13 +31,13 @@
           <p.matryoshka @items={{this.model.tokens}} as |token|>
             <code>
               {{page-title token.value replace=token.replace prepend=token.prepend separator=token.separator}}
-              \{{<span class="helper">page-title</span> "{{text-field class="string" value=token.value onchange=(action (mut token.value)) autoresize=true}}"
-              <span class="literal">separator</span>="{{text-field class="string" value=token.separator onchange=(action (mut token.separator)) autoresize=true}}"
-              <span class="literal">prepend</span>={{boolean-field class="attribute" value=token.prepend onchange=(action (mut token.prepend))}}
-              <span class="literal">replace</span>={{boolean-field class="attribute" value=token.replace onchange=(action (mut token.replace))~}} }}
+              \{{<span class="helper">page-title</span> "<TextField class="string" @value={{token.value}} @onchange={{action (mut token.value)}} @autoresize={{true}} />"
+              <span class="literal">separator</span>="<TextField class="string" @value={{token.separator}} @onchange={{action (mut token.separator)}} @autoresize={{true}} />"
+              <span class="literal">prepend</span>=<BooleanField class="attribute" @value={{token.prepend}} @onchange={{action (mut token.prepend)}} />
+              <span class="literal">replace</span>=<BooleanField class="attribute" @value={{token.replace}} @onchange={{action (mut token.replace)}} />}}
             </code>
           </p.matryoshka>
-          <button type="button" onclick={{action "add" model.tokens}}>Add title</button>
+          <button type="button" onclick={{action "add" this.model.tokens}}>Add title</button>
         </PageTitlePane>
       </div>
     </section>

--- a/tests/dummy/app/index/template.hbs
+++ b/tests/dummy/app/index/template.hbs
@@ -18,17 +18,17 @@
     <section id="installation">
       <h2>Installation</h2>
       <div class="grid">
-        {{#window-pane}}
+        <WindowPane>
           <span class="ps1">&gt; </span>ember install ember-page-title
-        {{/window-pane}}
+        </WindowPane>
       </div>
     </section>
 
     <section id="playground">
       <h2>Playground</h2>
       <div class="grid">
-        {{#page-title-pane as |p|}}
-          {{#p.matryoshka items=model.tokens as |token|}}
+        <PageTitlePane as |p|>
+          <p.matryoshka @items={{this.model.tokens}} as |token|>
             <code>
               {{page-title token.value replace=token.replace prepend=token.prepend separator=token.separator}}
               \{{<span class="helper">page-title</span> "{{text-field class="string" value=token.value onchange=(action (mut token.value)) autoresize=true}}"
@@ -36,10 +36,9 @@
               <span class="literal">prepend</span>={{boolean-field class="attribute" value=token.prepend onchange=(action (mut token.prepend))}}
               <span class="literal">replace</span>={{boolean-field class="attribute" value=token.replace onchange=(action (mut token.replace))~}} }}
             </code>
-          {{/p.matryoshka}}
-
+          </p.matryoshka>
           <button type="button" onclick={{action "add" model.tokens}}>Add title</button>
-        {{/page-title-pane}}
+        </PageTitlePane>
       </div>
     </section>
 
@@ -48,14 +47,14 @@
       <div class="grid">
         <div class="info">
           <p>To start using ember-page-title, add the name of your application into <code class="inline">application.hbs</code></p>
-          <p>This sets the title for your application. When your application loads, you should see the title &ldquo;{{model.title}}&rdquo; appear in the window. Try changing the value below to change the title of this page.</p>
+          <p>This sets the title for your application. When your application loads, you should see the title &ldquo;{{this.model.title}}&rdquo; appear in the window. Try changing the value below to change the title of this page.</p>
 
-          {{input type="text" value=model.title placeholder="My App"}}
+          <Input type="text" value={{this.model.title}} placeholder="My App"/>
         </div>
 
-        {{#window-pane title="templates/application.hbs"}}
-          <code>{{highlight '{{page-title "' model.title '"}}'}}</code>
-        {{/window-pane}}
+        <WindowPane @title="templates/application.hbs">
+          <code>{{highlight '{{page-title "' this.model.title '"}}'}}</code>
+        </WindowPane>
       </div>
 
       <div class="grid">
@@ -63,17 +62,17 @@
           <p>By default, using the helper will allow an interaction where additional titles are appended to the root:</p>
         </div>
 
-        {{#page-title-pane as |p|}}
-          {{#p.template title=model.title}}
-            <code>{{highlight '{{page-title "' model.title '"}}'}}</code>
-            {{#p.template title="Posts"}}
+        <PageTitlePane as |p|>
+          <p.template @title={{this.model.title}}>
+            <code>{{highlight '{{page-title "' this.model.title '"}}'}}</code>
+            <p.template title="Posts">
               <code>{{highlight '{{page-title "Posts"}}'}}</code>
-              {{#p.template title=model.post.title}}
+              <p.template @title={{this.model.post.title}}>
                 <code>{{highlight '{{page-title post.title}}'}}</code>
-              {{/p.template}}
-            {{/p.template}}
-          {{/p.template}}
-        {{/page-title-pane}}
+              </p.template>
+            </p.template>
+          </p.template>
+        </PageTitlePane>
       </div>
 
       <div class="grid">
@@ -81,17 +80,17 @@
           <p>You can change the separator by specifying the <code class="inline"><span class="attribute">separator</span></code> attribute.</p>
         </div>
 
-        {{#page-title-pane as |p|}}
-          {{#p.template title=model.title separator=" > "}}
-            <code>{{highlight '{{page-title "' model.title '" separator=" > "}}'}}</code>
-            {{#p.template title="Posts"}}
+        <PageTitlePane as |p|>
+          <p.template @title={{this.model.title}} @separator=" > ">
+            <code>{{highlight '{{page-title "' this.model.title '" separator=" > "}}'}}</code>
+            <p.template @title="Posts">
               <code>{{highlight '{{page-title "Posts"}}'}}</code>
-              {{#p.template title=model.post.title}}
+              <p.template @title={{this.model.post.title}}>
                 <code>{{highlight '{{page-title post.title}}'}}</code>
-              {{/p.template}}
-            {{/p.template}}
-          {{/p.template}}
-        {{/page-title-pane}}
+              </p.template>
+            </p.template>
+          </p.template>
+        </PageTitlePane>
       </div>
 
       <div class="grid">
@@ -99,17 +98,17 @@
           <p>Separators can be changed at arbitrary levels:</p>
         </div>
 
-        {{#page-title-pane as |p|}}
-          {{#p.template title=model.title separator=": "}}
-            <code>{{highlight '{{page-title "' model.title '" separator=": "}}'}}</code>
-            {{#p.template title="Posts" separator=" > "}}
+        <PageTitlePane as |p|>
+          <p.template @title={{this.model.title}} @separator=": ">
+            <code>{{highlight '{{page-title "' this.model.title '" separator=": "}}'}}</code>
+            <p.template @title="Posts" @separator=" > ">
               <code>{{highlight '{{page-title "Posts" separator=" > "}}'}}</code>
-              {{#p.template title=model.post.title}}
+              <p.template @title={{this.model.post.title}}>
                 <code>{{highlight '{{page-title post.title}}'}}</code>
-              {{/p.template}}
-            {{/p.template}}
-          {{/p.template}}
-        {{/page-title-pane}}
+              </p.template>
+            </p.template>
+          </p.template>
+        </PageTitlePane>
       </div>
 
       <div class="grid">
@@ -117,17 +116,17 @@
           <p>Titles can be prepended to the parent, by setting the <code class="inline"><span class="attribute">prepend</span></code> attribute to <code class="inline">{{highlight "true"}}</code>.</p>
         </div>
 
-        {{#page-title-pane as |p|}}
-          {{#p.template title=model.title prepend=true}}
-            <code>{{highlight '{{page-title "' model.title '" prepend=true}}'}}</code>
-            {{#p.template title="Posts"}}
+        <PageTitlePane as |p|>
+          <p.template @title={{this.model.title}} @prepend={{true}}>
+            <code>{{highlight '{{page-title "' this.model.title '" prepend=true}}'}}</code>
+            <p.template @title="Posts">
               <code>{{highlight '{{page-title "Posts"}}'}}</code>
-              {{#p.template title=model.post.title}}
+              <p.template @title={{this.model.post.title}}>
                 <code>{{highlight '{{page-title post.title}}'}}</code>
-              {{/p.template}}
-            {{/p.template}}
-          {{/p.template}}
-        {{/page-title-pane}}
+              </p.template>
+            </p.template>
+          </p.template>
+        </PageTitlePane>
       </div>
 
       <div class="grid">
@@ -135,17 +134,17 @@
           <p>This allows one to swap the order at arbitrary levels:</p>
         </div>
 
-        {{#page-title-pane as |p|}}
-          {{#p.template title=model.title}}
-            <code>{{highlight '{{page-title "' model.title '"}}'}}</code>
-            {{#p.template title="Posts" prepend=true}}
+        <PageTitlePane as |p|>
+          <p.template @title={{this.model.title}}>
+            <code>{{highlight '{{page-title "' this.model.title '"}}'}}</code>
+            <p.template @title="Posts" @prepend={{true}}>
               <code>{{highlight '{{page-title "Posts" prepend=true}}'}}</code>
-              {{#p.template title=model.post.title}}
+              <p.template @title={{this.model.post.title}}>
                 <code>{{highlight '{{page-title post.title}}'}}</code>
-              {{/p.template}}
-            {{/p.template}}
-          {{/p.template}}
-        {{/page-title-pane}}
+              </p.template>
+            </p.template>
+          </p.template>
+        </PageTitlePane>
       </div>
 
       <div class="grid">
@@ -153,17 +152,17 @@
           <p>And for special templates that need to complete control over the title, set the <code class="inline"><span class="attribute">replace</span></code> attribute to <code class="inline">{{highlight "true"}}</code>. This will only apply for that level.</p>
         </div>
 
-        {{#page-title-pane as |p|}}
-          {{#p.template title=model.title}}
-            <code>{{highlight '{{page-title "' model.title '"}}'}}</code>
-            {{#p.template title="Posts" replace=true}}
+        <PageTitlePane as |p|>
+          <p.template @title={{this.model.title}}>
+            <code>{{highlight '{{page-title "' this.model.title '"}}'}}</code>
+            <p.template @title="Posts" @replace={{true}}>
               <code>{{highlight '{{page-title "Posts" replace=true}}'}}</code>
-              {{#p.template title=model.post.title}}
-                <code>{{highlight '{{page-title model.post.title}}'}}</code>
-              {{/p.template}}
-            {{/p.template}}
-          {{/p.template}}
-        {{/page-title-pane}}
+              <p.template @title={{this.model.post.title}}>
+                <code>{{highlight '{{page-title this.model.post.title}}'}}</code>
+              </p.template>
+            </p.template>
+          </p.template>
+        </PageTitlePane>
       </div>
 
       <div class="grid">
@@ -171,26 +170,26 @@
           <p>In addition, there's no limit to the amount of titles you can put in a route:</p>
         </div>
 
-        {{#page-title-pane as |p|}}
-          {{#p.template title=model.title}}
-            <code>{{highlight '{{page-title "' model.title '"}}'}}</code>
-            {{#p.template title=(concat "Posts | " model.post.title)}}
+        <PageTitlePane as |p|>
+          <p.template @title={{this.model.title}}>
+            <code>{{highlight '{{page-title "' this.model.title '"}}'}}</code>
+            <p.template @title={{concat "Posts | " this.model.post.title}}>
               <code>{{highlight '{{page-title "Posts"}}'}}</code>
-              <code>{{highlight '{{page-title model.post.title}}'}}</code>
-            {{/p.template}}
-          {{/p.template}}
-        {{/page-title-pane}}
+              <code>{{highlight '{{page-title this.model.post.title}}'}}</code>
+            </p.template>
+          </p.template>
+        </PageTitlePane>
       </div>
 
       <div class="grid">
         <div class="info">
           <p>Dynamic tokens are available by providing multiple parameters to the helper:</p>
         </div>
-        {{#page-title-pane as |p|}}
-          {{#p.template title="Tim Evans (@timmyce)"}}
+        <PageTitlePane as |p|>
+          <p.template @title="Tim Evans (@timmyce)">
             <code>{{highlight '{{page-title blogger.name " (" blogger.handle ")"}}'}}</code>
-          {{/p.template}}
-        {{/page-title-pane}}
+          </p.template>
+        </PageTitlePane>
       </div>
     </section>
   </main>

--- a/tests/dummy/app/index/template.hbs
+++ b/tests/dummy/app/index/template.hbs
@@ -31,13 +31,13 @@
           <p.matryoshka @items={{this.model.tokens}} as |token|>
             <code>
               {{page-title token.value replace=token.replace prepend=token.prepend separator=token.separator}}
-              \{{<span class="helper">page-title</span> "<TextField class="string" @value={{token.value}} @onchange={{action (mut token.value)}} @autoresize={{true}} />"
-              <span class="literal">separator</span>="<TextField class="string" @value={{token.separator}} @onchange={{action (mut token.separator)}} @autoresize={{true}} />"
-              <span class="literal">prepend</span>=<BooleanField class="attribute" @value={{token.prepend}} @onchange={{action (mut token.prepend)}} />
-              <span class="literal">replace</span>=<BooleanField class="attribute" @value={{token.replace}} @onchange={{action (mut token.replace)}} />}}
+              \{{<span class="helper">page-title</span> "<TextField class="string" @value={{token.value}} @onchange={{fn (mut token.value)}} @autoresize={{true}} />"
+              <span class="literal">separator</span>="<TextField class="string" @value={{token.separator}} @onchange={{fn (mut token.separator)}} @autoresize={{true}} />"
+              <span class="literal">prepend</span>=<BooleanField class="attribute" @value={{token.prepend}} @onchange={{fn (mut token.prepend)}} />
+              <span class="literal">replace</span>=<BooleanField class="attribute" @value={{token.replace}} @onchange={{fn (mut token.replace)}} />}}
             </code>
           </p.matryoshka>
-          <button type="button" onclick={{action "add" this.model.tokens}}>Add title</button>
+          <button type="button" {{on "click" (fn this.add this.model.tokens)}}>Add title</button>
         </PageTitlePane>
       </div>
     </section>

--- a/tests/dummy/app/templates/author.hbs
+++ b/tests/dummy/app/templates/author.hbs
@@ -1,2 +1,2 @@
 {{page-title "Authors" prepend=false separator=" < "}}
-{{page-title model.name}}
+{{page-title this.model.name}}

--- a/tests/dummy/app/templates/feed.hbs
+++ b/tests/dummy/app/templates/feed.hbs
@@ -1,9 +1,9 @@
-{{page-title model.name " (" model.handle ")" replace=true}}
+{{page-title this.model.name " (" this.model.handle ")" replace=true}}
 
-{{#link-to "feed" "tomster" id="tomster"}}
+<LinkTo @route="feed" @model="tomster" id="tomster">
   @tomster
-{{/link-to}}
+</LinkTo>
 
-{{#link-to "feed" "zoey" id="zoey"}}
+<LinkTo @route="feed" @model="zoey" id="zoey">
   @zoey
-{{/link-to}}
+</LinkTo>

--- a/tests/dummy/app/templates/post.hbs
+++ b/tests/dummy/app/templates/post.hbs
@@ -1,2 +1,2 @@
 {{page-title "Posts"}}
-{{page-title model.title}}
+{{page-title this.model.title}}

--- a/yarn.lock
+++ b/yarn.lock
@@ -4943,7 +4943,7 @@ debug@~4.1.0:
   dependencies:
     ms "^2.1.1"
 
-debuglog@*, debuglog@^1.0.1:
+debuglog@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/debuglog/-/debuglog-1.0.1.tgz#aa24ffb9ac3df9a2351837cfb2d279360cd78492"
   integrity sha1-qiT/uaw9+aI1GDfPstJ5NgzXhJI=
@@ -8057,7 +8057,7 @@ import-lazy@^2.1.0:
   resolved "https://registry.yarnpkg.com/import-lazy/-/import-lazy-2.1.0.tgz#05698e3d45c88e8d7e9d92cb0584e77f096f3e43"
   integrity sha1-BWmOPUXIjo1+nZLLBYTnfwlvPkM=
 
-imurmurhash@*, imurmurhash@^0.1.4:
+imurmurhash@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
   integrity sha1-khi5srkoojixPcT7a21XbyMUU+o=
@@ -9155,11 +9155,6 @@ lodash._baseflatten@^3.0.0:
     lodash.isarguments "^3.0.0"
     lodash.isarray "^3.0.0"
 
-lodash._baseindexof@*:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/lodash._baseindexof/-/lodash._baseindexof-3.1.0.tgz#fe52b53a1c6761e42618d654e4a25789ed61822c"
-  integrity sha1-/lK1OhxnYeQmGNZU5KJXie1hgiw=
-
 lodash._baseuniq@~4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash._baseuniq/-/lodash._baseuniq-4.6.0.tgz#0ebb44e456814af7905c6212fa2c9b2d51b841e8"
@@ -9168,15 +9163,10 @@ lodash._baseuniq@~4.6.0:
     lodash._createset "~4.0.0"
     lodash._root "~3.0.0"
 
-lodash._bindcallback@*, lodash._bindcallback@^3.0.0:
+lodash._bindcallback@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz#e531c27644cf8b57a99e17ed95b35c748789392e"
   integrity sha1-5THCdkTPi1epnhftlbNcdIeJOS4=
-
-lodash._cacheindexof@*:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/lodash._cacheindexof/-/lodash._cacheindexof-3.0.2.tgz#3dc69ac82498d2ee5e3ce56091bafd2adc7bde92"
-  integrity sha1-PcaayCSY0u5ePOVgkbr9Ktx73pI=
 
 lodash._createassigner@^3.0.0:
   version "3.1.1"
@@ -9187,19 +9177,12 @@ lodash._createassigner@^3.0.0:
     lodash._isiterateecall "^3.0.0"
     lodash.restparam "^3.0.0"
 
-lodash._createcache@*:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/lodash._createcache/-/lodash._createcache-3.1.2.tgz#56d6a064017625e79ebca6b8018e17440bdcf093"
-  integrity sha1-VtagZAF2JeeevKa4AY4XRAvc8JM=
-  dependencies:
-    lodash._getnative "^3.0.0"
-
 lodash._createset@~4.0.0:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/lodash._createset/-/lodash._createset-4.0.3.tgz#0f4659fbb09d75194fa9e2b88a6644d363c9fe26"
   integrity sha1-D0ZZ+7CddRlPqeK4imZE02PJ/iY=
 
-lodash._getnative@*, lodash._getnative@^3.0.0:
+lodash._getnative@^3.0.0:
   version "3.9.1"
   resolved "https://registry.yarnpkg.com/lodash._getnative/-/lodash._getnative-3.9.1.tgz#570bc7dede46d61cdcde687d65d3eecbaa3aaff5"
   integrity sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=
@@ -9312,7 +9295,7 @@ lodash.omit@^4.1.0:
   resolved "https://registry.yarnpkg.com/lodash.omit/-/lodash.omit-4.5.0.tgz#6eb19ae5a1ee1dd9df0b969e66ce0b7fa30b5e60"
   integrity sha1-brGa5aHuHdnfC5aeZs4Lf6MLXmA=
 
-lodash.restparam@*, lodash.restparam@^3.0.0:
+lodash.restparam@^3.0.0:
   version "3.6.1"
   resolved "https://registry.yarnpkg.com/lodash.restparam/-/lodash.restparam-3.6.1.tgz#936a4e309ef330a7645ed4145986c85ae5b20805"
   integrity sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=
@@ -11799,7 +11782,7 @@ readable-stream@~1.1.10:
     isarray "0.0.1"
     string_decoder "~0.10.x"
 
-readdir-scoped-modules@*, readdir-scoped-modules@^1.0.0:
+readdir-scoped-modules@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/readdir-scoped-modules/-/readdir-scoped-modules-1.1.0.tgz#8d45407b4f870a0dcaebc0e28670d18e74514309"
   integrity sha512-asaikDeqAQg7JifRsZn1NJZXo9E+VwlyCfbkZhwyISinqk5zNS6266HS5kah6P0SaQKGF6SkNnZVHUzHFYxYDw==
@@ -14141,7 +14124,7 @@ v8-compile-cache@^2.0.3, v8-compile-cache@^2.1.1:
   resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-2.1.1.tgz#54bc3cdd43317bca91e35dcaf305b1a7237de745"
   integrity sha512-8OQ9CL+VWyt3JStj7HX7/ciTL2V3Rl1Wf5OL+SNTm0yK1KvtReVulksyeRnCANHHuUxHlQig+JJDlUhBt1NQDQ==
 
-validate-npm-package-license@*, validate-npm-package-license@^3.0.1:
+validate-npm-package-license@^3.0.1:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz#fc91f6b9c7ba15c857f4cb2c5defeec39d4f410a"
   integrity sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==


### PR DESCRIPTION
This PR does bare minimum to get ember-tempate-lint pass. We also turned off `no-actions` rule for one component until is migrated to Glimmer component.

Closes #171. 