### PR TITLE
fix: Use assign() from @ember/polyfills for IE11

### DIFF
--- a/addon/services/page-title-list.js
+++ b/addon/services/page-title-list.js
@@ -5,6 +5,7 @@ import Service, { inject as service } from '@ember/service';
 import { set, computed } from '@ember/object';
 import { capitalize } from '@ember/string';
 import { isPresent } from '@ember/utils';
+import { assign } from '@ember/polyfills';
 
 let isFastBoot = typeof FastBoot !== 'undefined';
 
@@ -177,7 +178,7 @@ export default class PageTitleListService extends Service {
         }
         let lastToken = group[0];
         if (lastToken) {
-          token = Object.assign({}, token);
+          token = assign({}, token);
           token.separator = lastToken.separator;
         }
         group.unshift(token);


### PR DESCRIPTION
Since Ember.js supports IE11 still, we cannot use `Object.assign()` directly.