### PR TITLE
fix: Dummy app hitting recently added assertion

### DIFF
--- a/tests/dummy/app/initializers/remove-default-title.js
+++ b/tests/dummy/app/initializers/remove-default-title.js
@@ -1,0 +1,22 @@
+/**
+ * This is here just for dummy app.
+ *
+ * Without it we would hit assertion from service:page-title-list
+ * because of our app/index.html has 2 <title> elements due to Fastboot.
+ *
+ * But having 2 <title> elements is intentional so we can acceptance test both
+ * browser and Fastboot scenarios together.
+ */
+export function initialize(/* application */) {
+  if (typeof FastBoot === 'undefined') {
+    let titleElements = document.head.getElementsByTagName('title');
+    let defaultTitle = titleElements.item(0);
+    if (defaultTitle && titleElements.length > 1) {
+      defaultTitle.parentElement.removeChild(defaultTitle);
+    }
+  }
+}
+
+export default {
+  initialize
+};


### PR DESCRIPTION
Currently dummy app crashes due to assertion over here - https://github.com/adopted-ember-addons/ember-page-title/commit/d4ea9bb8174c2ac8a9ece9031553e143dd10b661#diff-594a50941ede282499b14635c267e13fR248

But this exceptional case, because we intentionally include title elements twice to test Fastboot + Browser scenarios together.